### PR TITLE
Auth kill switch

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
@@ -113,13 +113,14 @@ namespace BrainCloud
         /// The user supplied callback object
         /// </param>
         public void AuthenticateAnonymous(
-            string externalId,
+            string anonymousId,
             bool forceCreate,
             SuccessCallback success = null,
             FailureCallback failure = null,
             object cbObject = null)
         {
-            Authenticate(externalId, "", AuthenticationType.Anonymous,
+            AnonymousId = anonymousId;
+            Authenticate(AnonymousId, "", AuthenticationType.Anonymous,
                               "", forceCreate, success, failure, cbObject);
         }
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
@@ -97,7 +97,7 @@ namespace BrainCloud
         /// Service Name - Authenticate
         /// Service Operation - Authenticate
         /// </remarks>
-        /// <param name="externalId">
+        /// <param name="anonymousId">
         /// provide an externalId, can be anything to keep anonymous
         /// </param>
         /// <param name="forceCreate">
@@ -120,8 +120,7 @@ namespace BrainCloud
             object cbObject = null)
         {
             AnonymousId = anonymousId;
-            Authenticate(AnonymousId, "", AuthenticationType.Anonymous,
-                              "", forceCreate, success, failure, cbObject);
+            AuthenticateAnonymous(forceCreate, success, failure, cbObject);
         }
 
         /// <summary>

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
@@ -44,8 +44,8 @@ namespace BrainCloud
         /// </param>
         public void Initialize(string profileId, string anonymousId)
         {
-            AnonymousId = anonymousId;
             ProfileId = profileId;
+            AnonymousId = anonymousId;
         }
 
         /// <summary>
@@ -85,6 +85,42 @@ namespace BrainCloud
         {
             Authenticate(AnonymousId, "", AuthenticationType.Anonymous,
                               null, forceCreate, success, failure, cbObject);
+        }
+
+        /// <summary>
+        /// Overloaded version AuthenticateAnonymous call, takes in more parameters. This is made as temporary
+        /// fix to this service's implementation structure. The AnonymousId of the regular call tends to be null
+        /// even after initializing the profileId and AnonId.This leads to an externalId missing error. This only
+        /// happens when the client uses the service directly and not through the Wrapper. 
+        /// </summary>
+        /// <remarks>
+        /// Service Name - Authenticate
+        /// Service Operation - Authenticate
+        /// </remarks>
+        /// <param name="externalId">
+        /// provide an externalId, can be anything to keep anonymous
+        /// </param>
+        /// <param name="forceCreate">
+        /// Should a new profile be created if it does not exist?
+        /// </param>
+        /// <param name="success">
+        /// The method to call in event of successful login
+        /// </param>
+        /// <param name="failure">
+        /// The method to call in the event of an error during authentication
+        /// </param>
+        /// <param name="cbObject">
+        /// The user supplied callback object
+        /// </param>
+        public void AuthenticateAnonymous(
+            string externalId,
+            bool forceCreate,
+            SuccessCallback success = null,
+            FailureCallback failure = null,
+            object cbObject = null)
+        {
+            Authenticate(externalId, "", AuthenticationType.Anonymous,
+                              "", forceCreate, success, failure, cbObject);
         }
 
         /// <summary>

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1438,7 +1438,7 @@ namespace BrainCloud.Internal
                     {
                         if(tooManyAuthenticationAttempts())
                         {
-                            FakeErrorResponse(requestState, StatusCodes.CLIENT_NETWORK_ERROR, ReasonCodes.CLIENT_DISABLED,
+                            FakeErrorResponse(requestState, StatusCodes.CLIENT_NETWORK_ERROR, ReasonCodes.CLIENT_DISABLED_FAILED_AUTH,
                                 "Client has been disabled due to identical repeat Authentication calls that are throwing errors. Authenticating with the same credentials is disabled for 30 seconds");
                             requestState = null;   
                         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1251,7 +1251,7 @@ namespace BrainCloud.Internal
                 _clientRef.Log("Current number of identical failed authentications: " + num);
                 
                 //have the attempts gone beyond the threshold?
-                if(_identicalFailedAuthenticationAttempts >= _identicalFailedAuthAttemptThreshold)
+                if(tooManyAuthenticationAttempts())
                 {
                     //we have a problem now, it seems they are contiuously trying to authenticate and sending us too many errors.
                     //we are going to now engage the killswitch and disable the client. This will act differently however. client will not

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -111,15 +111,9 @@ namespace BrainCloud.Internal
         ///is disabled.
         ///<summary>
         private int _failedAuthenticationAttemptThreshold = 3; 
-        
-        ///<summary>
-        ///The current number of failed attempts at authenticating. This 
-        ///will reset when a successful authentication is made.
-        ///<summary>
-        private int _failedAuthenticationAttempts = 0;
 
         ///<summary>
-        ///The current number of failed attempts at authenticating. This 
+        ///The current number of identical failed attempts at authenticating. This 
         ///will reset when a successful authentication is made.
         ///<summary>
         private int _identicalFailedAuthenticationAttempts = 0;
@@ -144,7 +138,7 @@ namespace BrainCloud.Internal
         /// When we have too many authentication errors under the same credentials, 
         /// the client will not be able to try and authenticate again until the timer is up.
         /// </summary>
-        private TimeSpan _authenticationTimeoutDuration = TimeSpan.FromSeconds(0.015f);
+        private TimeSpan _authenticationTimeoutDuration = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// When the authentication timer began 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -144,7 +144,7 @@ namespace BrainCloud.Internal
         /// When we have too many authentication errors under the same credentials, 
         /// the client will not be able to try and authenticate again until the timer is up.
         /// </summary>
-        private TimeSpan _authenticationTimeoutDuration = TimeSpan.FromSeconds(0.01f);
+        private TimeSpan _authenticationTimeoutDuration = TimeSpan.FromSeconds(0.015f);
 
         /// <summary>
         /// When the authentication timer began 
@@ -1252,7 +1252,7 @@ namespace BrainCloud.Internal
             //did the client make an authentication call?
             if(operation == ServiceOperation.Authenticate.Value)
             {
-                _clientRef.Log("Failed authentication call");
+                _clientRef.Log("Failed Authentication Call");
 
                 string num;
                 num = _identicalFailedAuthenticationAttempts.ToString();
@@ -1315,9 +1315,6 @@ namespace BrainCloud.Internal
 
                             if (_serviceCallsWaiting[i].GetOperation() == ServiceOperation.Authenticate.Value)
                             {
-                                if(_tooManyFailedAuthentications == false)
-                                {
-                                _clientRef.Log("BLAAAAAAAAAAAAAAAAAAAAAAAAAAARGH");
                                 if (i != 0)
                                 {
                                     var call = _serviceCallsWaiting[i];
@@ -1327,10 +1324,6 @@ namespace BrainCloud.Internal
 
                                 numMessagesWaiting = 1;
                                 break;
-                                }
-                                else{
-                                    _clientRef.Log("ERRRRRRRRRRRRRRRRRRRRRRRRRRRROOOOOOOOOOOOOOOOORRRRRRRRRRRRRRRRRRRRRRRRR");
-                                }
                             }
                         }
 
@@ -1442,7 +1435,7 @@ namespace BrainCloud.Internal
                     {
                         if (_isAuthenticated || isAuth)
                         {
-                            _clientRef.Log("STIIIIIIIIIIIIIIIILLL SENDING HAHA");
+                            _clientRef.Log("SENDING REQUEST");
                             InternalSendMessage(requestState);
                         }
                         else
@@ -1456,7 +1449,7 @@ namespace BrainCloud.Internal
                         if(_tooManyFailedAuthentications == true)
                         {
                             FakeErrorResponse(requestState, StatusCodes.CLIENT_NETWORK_ERROR, ReasonCodes.CLIENT_DISABLED,
-                                "Client has been disabled due to identical repeat Authentication calls that are throwing errors. Authenticating with the same credentials is now disabled for 30 seconds");
+                                "Client has been disabled due to identical repeat Authentication calls that are throwing errors. Authenticating with the same credentials is disabled for 30 seconds");
                             requestState = null;   
                         }
                         else
@@ -1523,7 +1516,6 @@ namespace BrainCloud.Internal
             string jsonRequestString = JsonWriter.Serialize(packet);
             string sig = CalculateMD5Hash(jsonRequestString + SecretKey);
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #if UNITY_EDITOR
             //Sending Data to the Unity Debug Plugin for ease of developer debugging when in the Editor
             try

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1034,22 +1034,7 @@ namespace BrainCloud.Internal
                     //if it was an authentication call 
                     if(sc.GetOperation() == "AUTHENTICATE")
                     {
-                        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-                        //MAY NOT NEED
-                        //we want to keep track of the new profileId being used, and keep note of the last one we used. To see if they're making changes to their call
-                       // string profileIdInUse = ""; 
-                        //object profileIdObj = null;
-                        //store the last used profile Id into slot 1 and the newest in slot 0. This way we can keep both stored for when testing the killswitch conditions, and track changes. 
-                       // _recentlyUsedProfileIdsForAuth[1] = _recentlyUsedProfileIdsForAuth[0];
-                       // response.TryGetValue("profileId", out profileIdObj);
-                       // _recentlyUsedProfileIdsForAuth[0] = (string)profileIdObj;
-
-                        //simplified version with profileId only. 
-                        //if(_recentlyUsedProfileIdsForAuth[0] == _recentlyUsedProfileIdsForAuth[1])
-                        //{
-                        //    _identicalFailedAuthenticationAttempts++;
-                        //}
-                        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+                        //swap the recent responses, so you have the newest one, and the one last time you came through.
                         _recentResponseJsonData[1] = _recentResponseJsonData[0];
                         _recentResponseJsonData[0] = response;
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ReasonCodes.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ReasonCodes.cs
@@ -106,8 +106,8 @@ namespace BrainCloud
         public const int MISSING_PLAYER_ID = 40382;
         public const int DECODE_CONTEXT = 40383;
         public const int INVALID_QUERY_CONTEXT = 40384;
-        public const int INVALID_AMOUNT = 40385;
         public const int GROUP_MEMBER_NOT_FOUND = 40385;
+        public const int INVALID_AMOUNT = 40385;
         public const int INVALID_SORT = 40386;
         public const int GAME_NOT_FOUND = 40387;
         public const int GAMES_NOT_IN_SAME_COMPANY = 40388;
@@ -366,6 +366,7 @@ namespace BrainCloud
         public const int LEADERBOARD_ROTATION_ERROR = 40642;
         public const int INVALID_STORE_ID = 40700;
         public const int METHOD_DEPRECATED = 40701;
+        public const int INVALID_BILLING_PROVIDER_ID = 40702;
         public const int NO_TWITTER_CONSUMER_KEY = 500001;
         public const int NO_TWITTER_CONSUMER_SECRET = 500002;
         public const int INVALID_CONFIGURATION = 500003;

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ReasonCodes.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ReasonCodes.cs
@@ -400,6 +400,7 @@ namespace BrainCloud
         public const int CLIENT_UPLOAD_FILE_TIMED_OUT = 90101;
         public const int CLIENT_UPLOAD_FILE_UNKNOWN = 90102;
         public const int CLIENT_DISABLED = 90200;
+        public const int CLIENT_DISABLED_FAILED_AUTH = 90201;
         public const int CHILD_USER_MISSING = CHILD_PLAYER_MISSING;
         public const int DISABLED_APP = DISABLED_GAME;
         public const int APPS_NOT_IN_SAME_COMPANY = GAMES_NOT_IN_SAME_COMPANY;

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/StatusCodes.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/StatusCodes.cs
@@ -9,6 +9,8 @@ namespace BrainCloud
     {
         public const int OK = 200;
 
+        public const int ACCEPTED = 202;
+
         /// <summary>
         /// Status code for a client side error
         /// </summary>

--- a/BrainCloudClient/solution/vstudio/BrainCloud/BrainCloudRoomServer.cs
+++ b/BrainCloudClient/solution/vstudio/BrainCloud/BrainCloudRoomServer.cs
@@ -1,0 +1,74 @@
+﻿//----------------------------------------------------
+// brainCloud client source code
+// Copyright 2016 bitHeads, inc.
+//----------------------------------------------------
+
+using System.Collections.Generic;
+using BrainCloud.Internal;
+namespace BrainCloud
+{
+    public class BrainCloudRoomServer
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        internal BrainCloudRoomServer(BrainCloudClient in_client, RSComms in_comms)
+        {
+            m_clientRef = in_client;
+            m_commsLayer = in_comms;
+        }
+
+        /// <summary>
+        /// Requests the event server address
+        /// </summary>
+        public void Send(string in_message, Dictionary<string, object> in_options = null)
+        {
+            m_commsLayer.Send(in_message, in_options);
+        }
+        
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="in_connectionType"></param>
+        /// <param name="in_success"></param>
+        /// <param name="in_failure"></param>
+        /// <param name="cb_object"></param>
+        public void EnableRS(eRSConnectionType in_connectionType = eRSConnectionType.WEBSOCKET, Dictionary<string, object> in_options = null, SuccessCallback in_success = null, FailureCallback in_failure = null, object cb_object = null)
+        {
+            m_commsLayer.EnableRS(in_connectionType, in_options, in_success, in_failure, cb_object);
+        }
+
+        /// <summary>
+        /// Disables Room Service for this session.
+        /// </summary>
+        public void DisableRS()
+        {
+            m_commsLayer.DisableRS();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void RegisterRSCallback(RSCallback in_callback)
+        {
+            m_commsLayer.RegisterRSCallback(in_callback);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void DeregisterRSCallback()
+        {
+            m_commsLayer.DeregisterRSCallback();
+        }
+
+        #region private
+        /// <summary>
+        /// Reference to the brainCloud client object
+        /// </summary>
+        private BrainCloudClient m_clientRef;
+        private RSComms m_commsLayer;
+        #endregion
+
+    }
+}

--- a/BrainCloudClient/solution/vstudio/BrainCloud/Internal/RSComms.cs
+++ b/BrainCloudClient/solution/vstudio/BrainCloud/Internal/RSComms.cs
@@ -1,0 +1,311 @@
+//----------------------------------------------------
+// brainCloud client source code
+// Copyright 2016 bitHeads, inc.
+//----------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Net.Sockets;
+using JsonFx.Json;
+
+namespace BrainCloud.Internal
+{
+    internal sealed class RSComms
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public RSComms(BrainCloudClient in_client)
+        {
+            m_clientRef = in_client;
+        }
+
+        /// <summary>
+        /// Enables Real Time event for this session.
+        /// Real Time events are disabled by default. Usually events
+        /// need to be polled using GET_EVENTS. By enabling this, events will
+        /// be received instantly when they happen through a TCP connection to an Event Server.
+        ///
+        ///This function will first call requestClientConnection, then connect to the address
+        /// </summary>
+        /// <param name="in_connectionType"></param>
+        /// <param name="in_success"></param>
+        /// <param name="in_failure"></param>
+        /// <param name="cb_object"></param>
+        public void EnableRS(eRSConnectionType in_connectionType = eRSConnectionType.WEBSOCKET, Dictionary<string, object> in_options = null, SuccessCallback in_success = null, FailureCallback in_failure = null, object cb_object = null)
+        {
+            if (!m_bIsConnected)
+            {
+                m_connectedSuccessCallback = in_success;
+                m_connectionFailureCallback = in_failure;
+                m_connectedObj = cb_object;
+
+                m_connectionOptions = in_options;
+                m_useWebSocket = in_connectionType == eRSConnectionType.WEBSOCKET;
+                connectWebSocket();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Send(string in_message, Dictionary<string, object> in_dict)
+        {
+            send(in_message);
+        }
+
+        /// <summary>
+        /// Disables Real Time event for this session.
+        /// </summary>
+        public void DisableRS()
+        {
+            addRSCommandResponse(new RSCommandResponse(ServiceName.RoomServer.Value, "disconnect", "DisableRS Called"));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        ///
+        public void RegisterRSCallback(RSCallback in_callback)
+        {
+            m_registeredCallbacks = in_callback;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void DeregisterRSCallback()
+        {
+            m_registeredCallbacks = null;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void Update()
+        {
+            RSCommandResponse toProcessResponse;
+            lock (m_queuedRSCommands)
+            {
+                for (int i = 0; i < m_queuedRSCommands.Count; ++i)
+                {
+                    toProcessResponse = m_queuedRSCommands[i];
+
+                    if (m_bIsConnected && m_connectedSuccessCallback != null && toProcessResponse.Operation == "connect")
+                    {
+                        m_connectedSuccessCallback(toProcessResponse.JsonMessage, m_connectedObj);
+                    }
+                    else if (m_bIsConnected && m_connectionFailureCallback != null &&
+                        toProcessResponse.Operation == "error" || toProcessResponse.Operation == "disconnect")
+                    {
+                        if (toProcessResponse.Operation == "disconnect")
+                            disconnect();
+
+                        // TODO:
+                        if (m_connectionFailureCallback != null)
+                            m_connectionFailureCallback(400, -1, toProcessResponse.JsonMessage, m_connectedObj);
+                    }
+                    
+                    if (!m_bIsConnected && toProcessResponse.Operation == "connect")
+                    {
+                        m_bIsConnected = true;
+                        send(buildConnectionRequest());
+                    }
+
+                    if (m_registeredCallbacks != null)
+                        m_registeredCallbacks(toProcessResponse.JsonMessage);
+                }
+
+                m_queuedRSCommands.Clear();
+            }
+        }
+
+        #region private
+        private string buildConnectionRequest()
+        {
+            Dictionary<string, object> json = new Dictionary<string, object>();
+            json["op"] = "CONNECT";
+            json["profileId"] = m_clientRef.ProfileId;
+            json["lobbyId"] = m_connectionOptions["lobbyId"] as string;
+
+            return JsonWriter.Serialize(json);
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        private void connectWebSocket()
+        {
+            if (!m_bIsConnected)
+            {
+                startReceivingWebSocket();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void disconnect()
+        {
+            if (m_webSocket != null) m_webSocket.Close();
+
+            m_webSocket = null;
+
+            m_bIsConnected = false;
+        }
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        private bool send(string in_message)
+        {
+            bool bMessageSent = false;
+            // early return
+            if ((!m_useWebSocket && m_tcpClient == null) ||
+                (m_useWebSocket && m_webSocket == null))
+            {
+                return bMessageSent;
+            }
+            
+            try
+            {
+                m_clientRef.Log("RS SEND: " + in_message);
+
+                // TCP 
+                if (!m_useWebSocket)
+                {
+                    // Get a stream object for writing. 			
+                    NetworkStream stream = m_tcpClient.GetStream();
+
+                    // Convert string message to byte array.                 
+                    byte[] clientMessageAsByteArray = Encoding.ASCII.GetBytes(in_message);
+
+                    // Write byte array to tcpConnection stream.                 
+                    stream.Write(clientMessageAsByteArray, 0, clientMessageAsByteArray.Length);
+                    stream.Flush();
+                    bMessageSent = true;
+                }
+                // web socket
+                else
+                {
+                    byte[] data = Encoding.UTF8.GetBytes(in_message);
+                    m_webSocket.SendAsync(data);
+                }
+            }
+            catch (SocketException socketException)
+            {
+                m_clientRef.Log("send exception: " + socketException);
+                addRSCommandResponse(new RSCommandResponse(ServiceName.RoomServer.Value, "error", socketException.ToString()));
+            }
+
+            return bMessageSent;
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        private void startReceivingWebSocket()
+        {
+            bool sslEnabled = (bool)m_connectionOptions["ssl"];
+            string url = (sslEnabled ? "wss://" : "ws://") + m_connectionOptions["host"] as string + ":" + (int)m_connectionOptions["port"];
+            setupWebSocket(url);
+        }
+
+        private void setupWebSocket(string in_url)
+        {
+            m_webSocket = new BrainCloudWebSocket(in_url);
+            m_webSocket.OnClose += WebSocket_OnClose;
+            m_webSocket.OnOpen += Websocket_OnOpen;
+            m_webSocket.OnMessage += WebSocket_OnMessage;
+            m_webSocket.OnError += WebSocket_OnError;
+        }
+
+        private void WebSocket_OnClose(BrainCloudWebSocket sender, int code, string reason)
+        {
+            m_clientRef.Log("Connection closed: " + reason);
+            addRSCommandResponse(new RSCommandResponse(ServiceName.RoomServer.Value, "disconnect", reason));
+        }
+
+        private void Websocket_OnOpen(BrainCloudWebSocket accepted)
+        {
+            m_clientRef.Log("Connection established.");
+            addRSCommandResponse(new RSCommandResponse(ServiceName.RoomServer.Value, "connect", ""));
+        }
+
+        private void WebSocket_OnMessage(BrainCloudWebSocket sender, byte[] data)
+        {
+            string message = Encoding.UTF8.GetString(data);
+            onRecv(message);
+        }
+
+        private void WebSocket_OnError(BrainCloudWebSocket sender, string message)
+        {
+            m_clientRef.Log("Error: " + message);
+            addRSCommandResponse(new RSCommandResponse(ServiceName.RoomServer.Value, "error", message));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void onRecv(string in_message)
+        {
+            m_clientRef.Log("RS RECV: " + in_message);
+            addRSCommandResponse(new RSCommandResponse(ServiceName.RoomServer.Value, "onrecv", in_message));
+        }
+        
+        private void addRSCommandResponse(RSCommandResponse in_command)
+        {
+            lock (m_queuedRSCommands)
+            {
+                m_queuedRSCommands.Add(in_command);
+            }
+        }
+
+        private TcpClient m_tcpClient;
+        private Dictionary<string, object> m_connectionOptions = null;
+        
+        private bool m_useWebSocket = false;
+        private bool m_bIsConnected = false;
+        private BrainCloudWebSocket m_webSocket = null;
+        
+        private const int MAX_PACKETSIZE = 1024;// TODO:: based off of some config 
+
+        private BrainCloudClient m_clientRef;
+
+        // success callbacks
+        private SuccessCallback m_connectedSuccessCallback = null;
+        private FailureCallback m_connectionFailureCallback = null;
+        private object m_connectedObj = null;
+        
+        private RSCallback m_registeredCallbacks = null;
+        private List<RSCommandResponse> m_queuedRSCommands = new List<RSCommandResponse>();
+
+        private struct RSCommandResponse
+        {
+            public RSCommandResponse(string in_service, string in_op, string in_msg)
+            {
+                Service = in_service;
+                Operation = in_op;
+                JsonMessage = in_msg;
+            }
+            public string Service { get; set; }
+            public string Operation { get; set; }
+            public string JsonMessage { get; set; }
+        }
+        #endregion
+    }
+}
+
+namespace BrainCloud
+{
+    #region public enums
+    public enum eRSConnectionType
+    {
+        INVALID,
+        WEBSOCKET,
+
+        MAX
+    }
+    #endregion
+}
+

--- a/BrainCloudClient/solution/vstudio/BrainCloudClient.csproj
+++ b/BrainCloudClient/solution/vstudio/BrainCloudClient.csproj
@@ -103,6 +103,8 @@
     <Compile Include="..\..\Assets\BrainCloud\Client\BrainCloud\BrainCloudFile.cs">
       <Link>BrainCloud\BrainCloudFile.cs</Link>
     </Compile>
+    <Compile Include="BrainCloud\BrainCloudRoomServer.cs" />
+    <Compile Include="BrainCloud\Internal\RSComms.cs" />
     <Content Include="C:\Codez\Libs\Folder\OtherFolder\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -81,7 +81,7 @@ namespace BrainCloudTests
                true,
                tr5.ApiSuccess, tr5.ApiError
              ); 
-            tr5.RunExpectFail(StatusCodes.CLIENT_NETWORK_ERROR, CLIENT_DISABLED);
+            tr5.RunExpectFail(StatusCodes.CLIENT_NETWORK_ERROR, ReasonCodes.CLIENT_DISABLED);
 
             //Now that the timer has refreshed in comms after waiting out the time, we should now be able to call another authenticate call. 
             TestResult tr6 = new TestResult(_bc);

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using BrainCloud;
 using System.Collections.Generic;
 using JsonFx.Json;
+using System;
 
 namespace BrainCloudTests
 {
@@ -23,76 +24,15 @@ namespace BrainCloudTests
             // //This threatens our servers, because huge numbers of errors related to the profileId not matching the anonymousId show up, as the user continues to have this retry. 
             // //Our goal is to stop this by checking to see if the call being made was an authentication call, then seeing if the attempted parameters for the authenticate were the
             // //same. If they were, we know they're simply retrying, and retrying, and we can send a client error saying that the credentials have already been retried. 
-
-            // //start test by initializing an anonymous Id and profileID
-            // string anonId = _bc.Client.AuthenticationService.GenerateAnonymousId();
-            // _bc.Client.AuthenticationService.Initialize("randomProfileId", anonId);
-
-            // //in this test case I am going to spam the anonymous authentication 4 times, I expect failure to happen with these calls. When the failure calls exceed 
-            // //the max that we allow, the client becomes disabled due to repeated errors from the authentication call.  
-            // TestResult tr = new TestResult(_bc);
-            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
-            //     "",
-            //    true,
-            //    tr.ApiSuccess, tr.ApiError
-            //  ); 
-            // tr.RunExpectFail(202, 40207);
-
-            // TestResult tr2 = new TestResult(_bc);
-            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
-            //     "",
-            //    true,
-            //    tr2.ApiSuccess, tr2.ApiError
-            //  ); 
-            // tr2.RunExpectFail(202, 40207);
-
-            // TestResult tr3 = new TestResult(_bc);
-            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
-            //     "",
-            //    true,
-            //    tr3.ApiSuccess, tr3.ApiError
-            //  ); 
-            // tr3.RunExpectFail(202, 40207);
-
-            // TestResult tr4 = new TestResult(_bc);
-            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
-            //     "",
-            //    true,
-            //    tr4.ApiSuccess, tr4.ApiError
-            //  ); 
-            // tr4.RunExpectFail(202, 40207);
-
-            // //At this point, I expect we the max error count and the client is disabled 
-            // //currently testing it as disabled for 0.01 seconds so it should skip this call.
-            // TestResult tr5 = new TestResult(_bc);
-            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
-            //     "",
-            //    true,
-            //    tr5.ApiSuccess, tr5.ApiError
-            //  ); 
-            // tr5.RunExpectFail(900, 90200);
-
-            // //The timer should finish by this call, and you will see that they can call authenticate again. 
-            // TestResult tr6 = new TestResult(_bc);
-            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
-            //     "",
-            //    true,
-            //    tr6.ApiSuccess, tr6.ApiError
-            //  );  
-            //  tr6.RunExpectFail(202, 40207);
-
-
-                        //our problem is that users who find they can't log in, will retry over and over until they have success. They do not change their credentials while doing this.
-            //This threatens our servers, because huge numbers of errors related to the profileId not matching the anonymousId show up, as the user continues to have this retry. 
-            //Our goal is to stop this by checking to see if the call being made was an authentication call, then seeing if the attempted parameters for the authenticate were the
-            //same. If they were, we know they're simply retrying, and retrying, and we can send a client error saying that the credentials have already been retried. 
-
+            
             //start test by initializing an anonymous Id and profileID
             string anonId = _bc.Client.AuthenticationService.GenerateAnonymousId();
             _bc.Client.AuthenticationService.Initialize("randomProfileId", anonId);
 
-            //in this test case I am going to spam the anonymous authentication 4 times, I expect failure to happen with these calls. When the failure calls exceed 
-            //the max that we allow, the client becomes disabled due to repeated errors from the authentication call.  
+            //in this test I purposefully fail 4 times so that 3 identical call will have been made after the first
+            //I then allow a fifth call to show that whenever a call is made it will simply hit the client with a fake response. 
+            //Then I freeze the test in a while loop for 30 seconds to wait out the comms timer. 
+            //then I call authenticate again and you will notice that a call will be made to the server and everything reset. 
             TestResult tr = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
@@ -125,6 +65,16 @@ namespace BrainCloudTests
              ); 
             tr4.RunExpectFail(202, 40207);
 
+            DateTime _testPauseStart = DateTime.Now;
+            TimeSpan _testPauseDuration = TimeSpan.FromSeconds(35);
+
+            //now that we've had out tests exceed the max failed tests, we will make a timer for the test to wait out the timer in comms.
+            while (!(DateTime.Now.Subtract(_testPauseStart) >= _testPauseDuration))
+            {
+                //putting the test into a while loop until it passes this condition
+            }
+
+            //based on the order of logic in comms, this test will get a fake response before the timer is finished so we expect the fake response. 
             TestResult tr5 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
@@ -133,29 +83,14 @@ namespace BrainCloudTests
              ); 
             tr5.RunExpectFail(900, 90200);
 
+            //Now that the timer has refreshed in comms after waiting out the time, we should now be able to call another authenticate call. 
             TestResult tr6 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
                true,
                tr6.ApiSuccess, tr6.ApiError
              );  
-             tr6.RunExpectFail(900, 90200);
-
-            TestResult tr7 = new TestResult(_bc);
-            _bc.Client.AuthenticationService.AuthenticateAnonymous(
-                "",
-               true,
-               tr7.ApiSuccess, tr7.ApiError
-             );  
-             tr7.RunExpectFail(202, 40207);
-
-            TestResult tr8 = new TestResult(_bc);
-            _bc.Client.AuthenticationService.AuthenticateAnonymous(
-                "",
-               true,
-               tr8.ApiSuccess, tr8.ApiError
-             );  
-             tr8.RunExpectFail(202, 40207);
+             tr6.RunExpectFail(202, 40207);
         }
 
         [Test]

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -62,7 +62,8 @@ namespace BrainCloudTests
              ); 
             tr4.RunExpectFail(202, 40207);
 
-            //by this point we expect calls the client to become disabled. 
+            //At this point, I expect we the max error count and the client is disabled 
+            //currently testing it as disabled for 0.01 seconds so it should skip this call.
             TestResult tr5 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
@@ -71,15 +72,14 @@ namespace BrainCloudTests
              ); 
             tr5.RunExpectFail(900, 90200);
 
-            //the client should still be disabled. 
+            //The timer should finish by this call, and you will see that they can call authenticate again. 
             TestResult tr6 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
                true,
                tr6.ApiSuccess, tr6.ApiError
              );  
-             tr6.RunExpectFail(900, 90200);
-            //tr6.RunExpectFail(900, 90200);
+             tr6.RunExpectFail(202, 40207);
         }
 
         [Test]

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -19,7 +19,70 @@ namespace BrainCloudTests
         [Test]
         public void TestAuthenticateSpam()
         {
-            //our problem is that users who find they can't log in, will retry over and over until they have success. They do not change their credentials while doing this.
+            // //our problem is that users who find they can't log in, will retry over and over until they have success. They do not change their credentials while doing this.
+            // //This threatens our servers, because huge numbers of errors related to the profileId not matching the anonymousId show up, as the user continues to have this retry. 
+            // //Our goal is to stop this by checking to see if the call being made was an authentication call, then seeing if the attempted parameters for the authenticate were the
+            // //same. If they were, we know they're simply retrying, and retrying, and we can send a client error saying that the credentials have already been retried. 
+
+            // //start test by initializing an anonymous Id and profileID
+            // string anonId = _bc.Client.AuthenticationService.GenerateAnonymousId();
+            // _bc.Client.AuthenticationService.Initialize("randomProfileId", anonId);
+
+            // //in this test case I am going to spam the anonymous authentication 4 times, I expect failure to happen with these calls. When the failure calls exceed 
+            // //the max that we allow, the client becomes disabled due to repeated errors from the authentication call.  
+            // TestResult tr = new TestResult(_bc);
+            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
+            //     "",
+            //    true,
+            //    tr.ApiSuccess, tr.ApiError
+            //  ); 
+            // tr.RunExpectFail(202, 40207);
+
+            // TestResult tr2 = new TestResult(_bc);
+            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
+            //     "",
+            //    true,
+            //    tr2.ApiSuccess, tr2.ApiError
+            //  ); 
+            // tr2.RunExpectFail(202, 40207);
+
+            // TestResult tr3 = new TestResult(_bc);
+            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
+            //     "",
+            //    true,
+            //    tr3.ApiSuccess, tr3.ApiError
+            //  ); 
+            // tr3.RunExpectFail(202, 40207);
+
+            // TestResult tr4 = new TestResult(_bc);
+            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
+            //     "",
+            //    true,
+            //    tr4.ApiSuccess, tr4.ApiError
+            //  ); 
+            // tr4.RunExpectFail(202, 40207);
+
+            // //At this point, I expect we the max error count and the client is disabled 
+            // //currently testing it as disabled for 0.01 seconds so it should skip this call.
+            // TestResult tr5 = new TestResult(_bc);
+            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
+            //     "",
+            //    true,
+            //    tr5.ApiSuccess, tr5.ApiError
+            //  ); 
+            // tr5.RunExpectFail(900, 90200);
+
+            // //The timer should finish by this call, and you will see that they can call authenticate again. 
+            // TestResult tr6 = new TestResult(_bc);
+            // _bc.Client.AuthenticationService.AuthenticateAnonymous(
+            //     "",
+            //    true,
+            //    tr6.ApiSuccess, tr6.ApiError
+            //  );  
+            //  tr6.RunExpectFail(202, 40207);
+
+
+                        //our problem is that users who find they can't log in, will retry over and over until they have success. They do not change their credentials while doing this.
             //This threatens our servers, because huge numbers of errors related to the profileId not matching the anonymousId show up, as the user continues to have this retry. 
             //Our goal is to stop this by checking to see if the call being made was an authentication call, then seeing if the attempted parameters for the authenticate were the
             //same. If they were, we know they're simply retrying, and retrying, and we can send a client error saying that the credentials have already been retried. 
@@ -62,8 +125,6 @@ namespace BrainCloudTests
              ); 
             tr4.RunExpectFail(202, 40207);
 
-            //At this point, I expect we the max error count and the client is disabled 
-            //currently testing it as disabled for 0.01 seconds so it should skip this call.
             TestResult tr5 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
@@ -72,14 +133,29 @@ namespace BrainCloudTests
              ); 
             tr5.RunExpectFail(900, 90200);
 
-            //The timer should finish by this call, and you will see that they can call authenticate again. 
             TestResult tr6 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
                 "",
                true,
                tr6.ApiSuccess, tr6.ApiError
              );  
-             tr6.RunExpectFail(202, 40207);
+             tr6.RunExpectFail(900, 90200);
+
+            TestResult tr7 = new TestResult(_bc);
+            _bc.Client.AuthenticationService.AuthenticateAnonymous(
+                "",
+               true,
+               tr7.ApiSuccess, tr7.ApiError
+             );  
+             tr7.RunExpectFail(202, 40207);
+
+            TestResult tr8 = new TestResult(_bc);
+            _bc.Client.AuthenticationService.AuthenticateAnonymous(
+                "",
+               true,
+               tr8.ApiSuccess, tr8.ApiError
+             );  
+             tr8.RunExpectFail(202, 40207);
         }
 
         [Test]

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -39,7 +39,7 @@ namespace BrainCloudTests
                true,
                tr.ApiSuccess, tr.ApiError
              ); 
-            tr.RunExpectFail(202, 40207);
+            tr.RunExpectFail(StatusCodes.ACCEPTED, ReasonCodes.SWITCHING_PROFILES);
 
             TestResult tr2 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
@@ -47,7 +47,7 @@ namespace BrainCloudTests
                true,
                tr2.ApiSuccess, tr2.ApiError
              ); 
-            tr2.RunExpectFail(202, 40207);
+            tr2.RunExpectFail(StatusCodes.ACCEPTED, ReasonCodes.SWITCHING_PROFILES);
 
             TestResult tr3 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
@@ -55,7 +55,7 @@ namespace BrainCloudTests
                true,
                tr3.ApiSuccess, tr3.ApiError
              ); 
-            tr3.RunExpectFail(202, 40207);
+            tr3.RunExpectFail(StatusCodes.ACCEPTED, ReasonCodes.SWITCHING_PROFILES);
 
             TestResult tr4 = new TestResult(_bc);
             _bc.Client.AuthenticationService.AuthenticateAnonymous(
@@ -63,7 +63,7 @@ namespace BrainCloudTests
                true,
                tr4.ApiSuccess, tr4.ApiError
              ); 
-            tr4.RunExpectFail(202, 40207);
+            tr4.RunExpectFail(StatusCodes.ACCEPTED, ReasonCodes.SWITCHING_PROFILES);
 
             DateTime _testPauseStart = DateTime.Now;
             TimeSpan _testPauseDuration = TimeSpan.FromSeconds(35);
@@ -81,7 +81,7 @@ namespace BrainCloudTests
                true,
                tr5.ApiSuccess, tr5.ApiError
              ); 
-            tr5.RunExpectFail(900, 90200);
+            tr5.RunExpectFail(StatusCodes.CLIENT_NETWORK_ERROR, CLIENT_DISABLED);
 
             //Now that the timer has refreshed in comms after waiting out the time, we should now be able to call another authenticate call. 
             TestResult tr6 = new TestResult(_bc);
@@ -90,7 +90,7 @@ namespace BrainCloudTests
                true,
                tr6.ApiSuccess, tr6.ApiError
              );  
-             tr6.RunExpectFail(202, 40207);
+             tr6.RunExpectFail(StatusCodes.ACCEPTED, ReasonCodes.SWITCHING_PROFILES);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace BrainCloudTests
                 true,
                 tr.ApiSuccess, tr.ApiError);
 
-            tr.RunExpectFail(202, 40207);
+            tr.RunExpectFail(StatusCodes.ACCEPTED, ReasonCodes.SWITCHING_PROFILES);
         }
 
         [Test]

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -81,7 +81,7 @@ namespace BrainCloudTests
                true,
                tr5.ApiSuccess, tr5.ApiError
              ); 
-            tr5.RunExpectFail(StatusCodes.CLIENT_NETWORK_ERROR, ReasonCodes.CLIENT_DISABLED);
+            tr5.RunExpectFail(StatusCodes.CLIENT_NETWORK_ERROR, ReasonCodes.CLIENT_DISABLED_FAILED_AUTH);
 
             //Now that the timer has refreshed in comms after waiting out the time, we should now be able to call another authenticate call. 
             TestResult tr6 = new TestResult(_bc);

--- a/BrainCloudClient/tests/TestAuthenticate.cs
+++ b/BrainCloudClient/tests/TestAuthenticate.cs
@@ -78,7 +78,8 @@ namespace BrainCloudTests
                true,
                tr6.ApiSuccess, tr6.ApiError
              );  
-            tr6.RunExpectFail(900, 90200);
+             tr6.RunExpectFail(900, 90200);
+            //tr6.RunExpectFail(900, 90200);
         }
 
         [Test]


### PR DESCRIPTION
Thoroughly tested. Need input. Are there things missing? Additions to be made? 
Currently, when multiple (3) identical authentication calls are made that throw errors, the client is unable to send another authentication call with the same parameters for 30 seconds. Instead of the server getting the call and sending an error, they receive a fake error response telling them this. 