### PR TITLE
BCLOUD-upload file from memory

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudFile.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudFile.cs
@@ -82,7 +82,8 @@ using System;
         /// <param name="cloudFilename">The desired cloud fileName of the file</param>
         /// <param name="shareable">True if the file is shareable</param>
         /// <param name="replaceIfExists">Whether to replace file if it exists</param>
-        /// <param name="fileData">The converted file data from memory in string format. if your memory data is in a byte[] you can use System.Convert.ToBase64String(bytes) to convert into a proper string format</param>
+        ///<param name="fileData">The converted file data from memory in string format.if your memory data is in a byte[] you can use System.Convert.ToBase64String(bytes) to convert into a proper string format</param>
+        /// <param name="localPath">path to file on disk</param>
         /// <param name="success">The success callback</param>
         /// <param name="failure">The failure callback</param>
         /// <param name="cbObject">The callback object</param>
@@ -92,17 +93,18 @@ using System;
             bool shareable,
             bool replaceIfExists,
             string fileData,
+            string localPath,
             SuccessCallback success = null,
             FailureCallback failure = null,
             object cbObject = null)
         {
             Dictionary<string, object> data = new Dictionary<string, object>();
-            data[OperationParam.UploadLocalPath.Value] = fileData;
+            data[OperationParam.UploadLocalPath.Value] = localPath;
             data[OperationParam.UploadCloudFilename.Value] = cloudFilename;
             data[OperationParam.UploadCloudPath.Value] = cloudPath;
             data[OperationParam.UploadShareable.Value] = shareable;
             data[OperationParam.UploadReplaceIfExists.Value] = replaceIfExists;
-
+            
             byte[] file = System.Convert.FromBase64String(fileData);
             data[OperationParam.UploadFileSize.Value] = file.Length;
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudFile.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudFile.cs
@@ -74,7 +74,7 @@ using System;
         
         /// <summary>
         /// Prepares a user file upload from memory, allowing the user to bypass 
-        //the need to read or write on disk before uploading. On success the file will begin uploading
+        /// the need to read or write on disk before uploading. On success the file will begin uploading
         /// to the brainCloud server.To be informed of success/failure of the upload
         /// register an IFileUploadCallback with the BrainCloudClient class.
         /// </summary>
@@ -93,13 +93,12 @@ using System;
             bool shareable,
             bool replaceIfExists,
             string fileData,
-            string localPath,
             SuccessCallback success = null,
             FailureCallback failure = null,
             object cbObject = null)
         {
             Dictionary<string, object> data = new Dictionary<string, object>();
-            data[OperationParam.UploadLocalPath.Value] = localPath;
+            data[OperationParam.UploadLocalPath.Value] = fileData;
             data[OperationParam.UploadCloudFilename.Value] = cloudFilename;
             data[OperationParam.UploadCloudPath.Value] = cloudPath;
             data[OperationParam.UploadShareable.Value] = shareable;

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudFile.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudFile.cs
@@ -15,7 +15,8 @@ using System;
     public class BrainCloudFile
     {
         private BrainCloudClient _client;
-
+        public Dictionary<string, byte[]> FileStorage = new Dictionary<string, byte[]>();
+        
         public BrainCloudFile(BrainCloudClient client)
         {
             _client = client;
@@ -34,6 +35,7 @@ using System;
         /// <param name="success">The success callback</param>
         /// <param name="failure">The failure callback</param>
         /// <param name="cbObject">The callback object</param>
+        [Obsolete("This has been deprecated use UploadFileFromMemory instead - removal after June 22nd 2022")]
         public bool UploadFile(
             string cloudPath,
             string cloudFilename,
@@ -47,31 +49,23 @@ using System;
 #if UNITY_WEBPLAYER || UNITY_WEBGL
             throw new Exception("FileUpload API is not supported on Web builds use FileUploadFromMemory instead");
 #else
-            FileInfo info = new FileInfo(localPath);
+            Stream info = new FileStream(localPath,FileMode.Open);
 
-            if (!info.Exists)
+            if (info.Length == 0)
             {
                 _client.Log("File at " + localPath + " does not exist");
                 return false;
             }
+            byte[] fileData = new Byte[(int)info.Length];
+            info.Seek(0, SeekOrigin.Begin);
+            info.Read(fileData, 0, (int)info.Length);
+            info.Close();
 
-            Dictionary<string, object> data = new Dictionary<string, object>();
-            data[OperationParam.UploadLocalPath.Value] = localPath;
-            data[OperationParam.UploadCloudFilename.Value] = cloudFilename;
-            data[OperationParam.UploadCloudPath.Value] = cloudPath;
-            data[OperationParam.UploadShareable.Value] = shareable;
-            data[OperationParam.UploadReplaceIfExists.Value] = replaceIfExists;
-            data[OperationParam.UploadFileSize.Value] = info.Length;
-
-            ServerCallback callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
-            ServerCall sc = new ServerCall(ServiceName.File, ServiceOperation.PrepareUserUpload, data, callback);
-            _client.SendRequest(sc);
-
-            return true;
+            return UploadFileFromMemory(cloudFilename, cloudFilename, shareable, replaceIfExists, fileData, success,
+                failure, cbObject);
 #endif
         }
 
-        
         /// <summary>
         /// Prepares a user file upload from memory, allowing the user to bypass 
         /// the need to read or write on disk before uploading. On success the file will begin uploading
@@ -82,8 +76,7 @@ using System;
         /// <param name="cloudFilename">The desired cloud fileName of the file</param>
         /// <param name="shareable">True if the file is shareable</param>
         /// <param name="replaceIfExists">Whether to replace file if it exists</param>
-        ///<param name="fileData">The converted file data from memory in string format.if your memory data is in a byte[] you can use System.Convert.ToBase64String(bytes) to convert into a proper string format</param>
-        /// <param name="localPath">path to file on disk</param>
+        /// <param name="fileData">The file memory data in byte[]</param>
         /// <param name="success">The success callback</param>
         /// <param name="failure">The failure callback</param>
         /// <param name="cbObject">The callback object</param>
@@ -92,21 +85,27 @@ using System;
             string cloudFilename,
             bool shareable,
             bool replaceIfExists,
-            string fileData,
+            byte[] fileData,
             SuccessCallback success = null,
             FailureCallback failure = null,
             object cbObject = null)
-        {
+        {   
+            if (fileData.Length == 0)
+            {
+                _client.Log("File data is empty");
+                return false;
+            }
+            string guid = Guid.NewGuid().ToString();
+            _client.FileService.FileStorage.Add(guid, fileData);
+            
             Dictionary<string, object> data = new Dictionary<string, object>();
-            data[OperationParam.UploadLocalPath.Value] = fileData;
+            data[OperationParam.UploadLocalPath.Value] = guid;
             data[OperationParam.UploadCloudFilename.Value] = cloudFilename;
             data[OperationParam.UploadCloudPath.Value] = cloudPath;
             data[OperationParam.UploadShareable.Value] = shareable;
             data[OperationParam.UploadReplaceIfExists.Value] = replaceIfExists;
+            data[OperationParam.UploadFileSize.Value] = fileData.Length;
             
-            byte[] file = System.Convert.FromBase64String(fileData);
-            data[OperationParam.UploadFileSize.Value] = file.Length;
-
             ServerCallback callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
             ServerCall sc = new ServerCall(ServiceName.File, ServiceOperation.PrepareUserUpload, data, callback);
             _client.SendRequest(sc);

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1042,9 +1042,16 @@ using UnityEngine.Experimental.Networking;
                             {
                                 string uploadId = (string)fileData["uploadId"];
                                 string localPath = (string)fileData["localPath"];
+                                string fileName = (string) fileData["cloudFilename"];
                                 var uploader = new FileUploader(uploadId, localPath, UploadURL, SessionID,
                                     _uploadLowTransferRateTimeout, _uploadLowTransferRateThreshold, _clientRef, peerCode);
-#if DOT_NET
+                                
+                                uploader.FileName = fileName;
+                                if (_clientRef.FileService.FileStorage.ContainsKey(localPath))
+                                {
+                                    uploader.TotalBytesToTransfer = _clientRef.FileService.FileStorage[localPath].Length;    
+                                }
+#if DOT_NET                     
                                 uploader.HttpClient = _httpClient;
 #endif
                                 _fileUploads.Add(uploader);

--- a/BrainCloudClient/tests/TestFile.cs
+++ b/BrainCloudClient/tests/TestFile.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Threading;
 using System;
 using System.Net;
-using System.Text;
 
 namespace BrainCloudTests
 {

--- a/BrainCloudClient/tests/TestFile.cs
+++ b/BrainCloudClient/tests/TestFile.cs
@@ -70,19 +70,17 @@ namespace BrainCloudTests
             TestResult tr = new TestResult(_bc);
             _bc.Client.RegisterFileUploadCallbacks(FileCallbackSuccess, FileCallbackFail);
 
-            string path = "D:/GitHub/braincloud-csharp/BrainCloudClient/tests/bitheads-logo.jpg";
-            
-            FileInfo info = new FileInfo(path);
-            Stream buffInfo = new FileStream(path, FileMode.Open);
+            string fileName = "file.txt";
+            FileStream file = File.Create(Path.Combine(Path.GetTempPath(), fileName), 100);
+            Stream buffInfo = file;
             string fileData = ConvertToBase64(buffInfo);
             buffInfo.Close();
             _bc.FileService.UploadFileFromMemory(
                 _cloudPath,
-                info.Name,
+                fileName,
                 true,
                 true,
                 fileData,
-                path,
                 tr.ApiSuccess, tr.ApiError);
             
             tr.Run();


### PR DESCRIPTION
- Created UploadFileFromMemory() with a couple of helper functions to convert file data into a byte array. 
- Made UploadFile a deprecated warning and changed the call to take the local path and get the file data then call UploadFileFromMemory.