### PR TITLE
Fix for _localPath that causes a Format Exception Error

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1048,15 +1048,15 @@ using UnityEngine.Experimental.Networking;
                             if (fileData.ContainsKey("uploadId") && fileData.ContainsKey("localPath"))
                             {
                                 string uploadId = (string)fileData["uploadId"];
-                                string localPath = (string)fileData["localPath"];
+                                string guid = (string)fileData["localPath"];
                                 string fileName = (string) fileData["cloudFilename"];
-                                var uploader = new FileUploader(uploadId, localPath, UploadURL, SessionID,
+                                var uploader = new FileUploader(uploadId, guid, UploadURL, SessionID,
                                     _uploadLowTransferRateTimeout, _uploadLowTransferRateThreshold, _clientRef, peerCode);
                                 
                                 uploader.FileName = fileName;
-                                if (_clientRef.FileService.FileStorage.ContainsKey(localPath))
+                                if (_clientRef.FileService.FileStorage.ContainsKey(guid))
                                 {
-                                    uploader.TotalBytesToTransfer = _clientRef.FileService.FileStorage[localPath].Length;    
+                                    uploader.TotalBytesToTransfer = _clientRef.FileService.FileStorage[guid].Length;    
                                 }
 #if DOT_NET                     
                                 uploader.HttpClient = _httpClient;

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/FileUploader.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/FileUploader.cs
@@ -68,7 +68,7 @@ using System.Threading.Tasks;
 #pragma warning disable 649
         private BrainCloudClient _client;
         private string _sessionId;
-        private string _localPath;
+        private string _guidLocalPath;
         private string _serverUrl;
         private string _fileName;
         private string _peerCode;
@@ -106,7 +106,7 @@ using System.Threading.Tasks;
 
         public FileUploader(
             string uploadId,
-            string localPath,
+            string guidLocalPath,
             string serverUrl,
             string sessionId,
             int timeout,
@@ -117,7 +117,7 @@ using System.Threading.Tasks;
             _client = client;
 
             UploadId = uploadId;
-            _localPath = localPath;
+            _guidLocalPath = guidLocalPath;
             _serverUrl = serverUrl;
             _sessionId = sessionId;
             _peerCode = peerCode;
@@ -131,16 +131,7 @@ using System.Threading.Tasks;
         {
 #if !UNITY_WEBPLAYER
 #if !DOT_NET
-            FileInfo info = new FileInfo(_localPath);
-            byte[] file;
-            if (info.Exists)
-            {
-                file = File.ReadAllBytes(_localPath);
-            }
-            else
-            {
-                file = System.Convert.FromBase64String(_localPath);
-            }
+            byte[] file = _client.FileService.FileStorage[_guidLocalPath];
             WWWForm postForm = new WWWForm();
             postForm.AddField("sessionId", _sessionId);
 
@@ -149,12 +140,12 @@ using System.Threading.Tasks;
             postForm.AddField("fileSize", file.Length);
             postForm.AddBinaryData("uploadFile", file, _fileName);
 
-#if USE_WEB_REQUEST
+    #if USE_WEB_REQUEST
             _request = UnityWebRequest.Post(_serverUrl, postForm);
             _request.SendWebRequest();
-#else
+    #else
             _request = new WWW(_serverUrl, postForm);
-#endif
+    #endif
 #else
             var requestMessage = new HttpRequestMessage()
             {

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/FileUploader.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/FileUploader.cs
@@ -297,7 +297,7 @@ using System.Threading.Tasks;
             if (StatusCode != StatusCodes.OK)
             {
                 Status = FileUploaderStatus.CompleteFailed;
-
+                _client.FileService.FileStorage.Remove(_guidLocalPath);
                 if (_request.error != null)
                 {
                     ReasonCode = ReasonCodes.CLIENT_UPLOAD_FILE_UNKNOWN;
@@ -331,7 +331,7 @@ using System.Threading.Tasks;
             else
             {
                 Status = FileUploaderStatus.CompleteSuccess;
-
+                _client.FileService.FileStorage.Remove(_guidLocalPath);
 #if USE_WEB_REQUEST
                 Response = _request.downloadHandler.text;
 #else


### PR DESCRIPTION
Error: FormatException: The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.

Reason: _localPath would direct the file that was created and then give the needed info for UploadFileFromMemory(). But once the response is received, the _localPath acts more of a GUID instead of a path. Not sure when this was changed.