### PR TITLE
Fix For Auth Advance As Anonymous Type

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPlayerState.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPlayerState.cs
@@ -74,9 +74,12 @@ using BrainCloud.Internal;
             FailureCallback failure = null,
             object cbObject = null)
         {
-            _client.Wrapper.ResetStoredAnonymousId();
-            _client.Wrapper.ResetStoredProfileId();
-            ServerCallback callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            SuccessCallback preCallback = (jsonData, cbObject) =>
+            {
+                _client.Wrapper.ResetStoredAnonymousId();
+                _client.Wrapper.ResetStoredProfileId();
+            };
+            ServerCallback callback = BrainCloudClient.CreateServerCallback(preCallback + success, failure, cbObject);
             ServerCall sc = new ServerCall(ServiceName.PlayerState, ServiceOperation.FullReset, null, callback);
             _client.SendRequest(sc);
         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPlayerState.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPlayerState.cs
@@ -74,6 +74,8 @@ using BrainCloud.Internal;
             FailureCallback failure = null,
             object cbObject = null)
         {
+            _client.Wrapper.ResetStoredAnonymousId();
+            _client.Wrapper.ResetStoredProfileId();
             ServerCallback callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
             ServerCall sc = new ServerCall(ServiceName.PlayerState, ServiceOperation.FullReset, null, callback);
             _client.SendRequest(sc);

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
@@ -1222,6 +1222,7 @@ public class BrainCloudWrapper
         bool isAnonymous = authenticationType == AuthenticationType.Anonymous;
         InitializeIdentity(isAnonymous);
         ids.externalId = isAnonymous ? GetStoredAnonymousId() : ids.externalId;
+        ids.authenticationToken = isAnonymous ? "" : ids.authenticationToken;
 
         Client.AuthenticationService.AuthenticateAdvanced(
             authenticationType, ids, forceCreate, extraJson, AuthSuccessCallback, AuthFailureCallback, aco);

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
@@ -1219,7 +1219,9 @@ public class BrainCloudWrapper
         aco._failureCallback = failure;
         aco._cbObject = cbObject;
         
-        InitializeIdentity();
+        bool isAnonymous = authenticationType == AuthenticationType.Anonymous;
+        InitializeIdentity(isAnonymous);
+        ids.externalId = isAnonymous ? GetStoredAnonymousId() : ids.externalId;
 
         Client.AuthenticationService.AuthenticateAdvanced(
             authenticationType, ids, forceCreate, extraJson, AuthSuccessCallback, AuthFailureCallback, aco);

--- a/BrainCloudClient/Assets/BrainCloud/UnityWebSocketsForWebGL/WebSocketSharp/websocket-sharp.csproj.meta
+++ b/BrainCloudClient/Assets/BrainCloud/UnityWebSocketsForWebGL/WebSocketSharp/websocket-sharp.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 11417954c285686448dc472e13b4ed51
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
@@ -179,6 +179,33 @@ namespace Tests.PlayMode
             yield return _tc.StartCoroutine(_tc.Run());
             LogResults("Failed to authenticate advanced with anonymous as the type", _tc.bcWrapper.Client.Authenticated);
         }
+        
+        //Testing to see if profile & anonymous id's get saved properly
+        [UnityTest]
+        public IEnumerator TestReauthenticateAnonymousAdvanced()
+        {
+            AuthenticationIds ids;
+            ids.externalId = "superNewUser";
+            ids.authenticationToken = "newToken";
+            ids.authenticationSubType = "";
+            Dictionary<string, object> extraJson = new Dictionary<string, object>();
+
+            _tc.bcWrapper.AuthenticateAdvanced(AuthenticationType.Anonymous, ids, true,
+                extraJson, _tc.ApiSuccess, _tc.ApiError);
+            yield return _tc.StartCoroutine(_tc.Run());
+            
+            _tc.bcWrapper.PlayerStateService.Logout(_tc.ApiSuccess, _tc.ApiError);
+            yield return _tc.StartCoroutine(_tc.Run());
+            
+            _tc.bcWrapper.AuthenticateAdvanced(AuthenticationType.Anonymous, ids, false,
+                extraJson, _tc.ApiSuccess, _tc.ApiError);
+            yield return _tc.StartCoroutine(_tc.Run());
+            
+            LogResults("Failed to reauthenticate", _tc.bcWrapper.Client.Authenticated);
+            
+            _tc.bcWrapper.PlayerStateService.DeleteUser(_tc.ApiSuccess, _tc.ApiError);
+            yield return _tc.StartCoroutine(_tc.Run());
+        }
 
         [UnityTest]
         public IEnumerator TestAuthenticateUltra()

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
@@ -173,7 +173,7 @@ namespace Tests.PlayMode
             ids.authenticationSubType = "";
             Dictionary<string, object> extraJson = new Dictionary<string, object>();
 
-            _tc.bcWrapper.AuthenticateAdvanced(AuthenticationType.Anonymous, ids, false,
+            _tc.bcWrapper.AuthenticateAdvanced(AuthenticationType.Anonymous, ids, true,
                 extraJson, _tc.ApiSuccess, _tc.ApiError);
 
             yield return _tc.StartCoroutine(_tc.Run());

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
@@ -165,6 +165,22 @@ namespace Tests.PlayMode
         }
         
         [UnityTest]
+        public IEnumerator TestAuthenticateAnonymousAdvanced()
+        {
+            AuthenticationIds ids;
+            ids.externalId = "advancedAnonymousUser";
+            ids.authenticationToken = "specialToken";
+            ids.authenticationSubType = "";
+            Dictionary<string, object> extraJson = new Dictionary<string, object>();
+
+            _tc.bcWrapper.AuthenticateAdvanced(AuthenticationType.Anonymous, ids, false,
+                extraJson, _tc.ApiSuccess, _tc.ApiError);
+
+            yield return _tc.StartCoroutine(_tc.Run());
+            LogResults("Failed to authenticate advanced with anonymous as the type", _tc.bcWrapper.Client.Authenticated);
+        }
+
+        [UnityTest]
         public IEnumerator TestAuthenticateUltra()
         {
             if (!ServerUrl.Contains("api-internal.braincloudservers.com") &&


### PR DESCRIPTION
Previously due to InitializeIdentity defaulting to false, it would ALWAYS wipe the profileId that is stored. Also made a check to switch the externalId to anonymousId if the AuthenticateType == Anonymous