### PR TITLE
Fix: Change to add https:// to Host URL

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudLobby.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudLobby.cs
@@ -569,7 +569,7 @@ using UnityEngine.Experimental.Networking;
 #if DOT_NET
             PingUpdateSystem(in_region, in_target);
 #else       
-            in_target = "http://" + in_target;
+            in_target = "https://" + in_target;
 
             if (m_clientRef.Wrapper != null)
                 m_clientRef.Wrapper.StartCoroutine(HandlePingReponse(in_region, in_target));


### PR DESCRIPTION
Pinging servers in `BrainCloudLobby.cs` adds `http://` to the host URL; however, the latest versions of Unity does not allow HTTP Get requests through through HTTP without changing the settings to allow downloads over HTTP. This is a quick fix to add `https://` to the host URL instead. Not sure if it's the best approach but it does work with Bombers.