### PR TITLE
Fix: BrainCloudLobby to use .NET Ping instead of UnityWebRequest

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudLobby.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudLobby.cs
@@ -569,7 +569,7 @@ using UnityEngine.Experimental.Networking;
 #if DOT_NET
             PingUpdateSystem(in_region, in_target);
 #else       
-            in_target = "http://" + in_target;
+            in_target = "https://" + in_target;
 
             if (m_clientRef.Wrapper != null)
                 m_clientRef.Wrapper.StartCoroutine(HandlePingReponse(in_region, in_target));


### PR DESCRIPTION
A more proper fix for **BrainCloudLobby** trying to ping servers to find the best region. I'm not sure what the original intent was with making use of **UnityWebRequest** but since `UnityWebRequest.Get()` with HTTP is a no-no for latest versions of Unity, using the basic .NET Ping classes should be the way to go.

Updated with a solution that works on Windows, Android and iOS. See the [comment below](https://github.com/getbraincloud/braincloud-csharp/pull/264#issuecomment-1724226977) for more information.