### PR TITLE
Fixes for Godot C#

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
@@ -1250,7 +1250,7 @@ using BrainCloud.JsonFx.Json;
 #if DOT_NET
             data["clientLib"] = "csharp";
 #elif GODOT
-            data["clientLib"] = "csharp-godot"
+            data["clientLib"] = "csharp-godot";
 #else
             data["clientLib"] = "csharp-unity";
 #endif

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudClient.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudClient.cs
@@ -1313,7 +1313,7 @@ using System.Globalization;
                     else
                     {
 #if GODOT
-                        GD.Print(formattedLog);
+                        Godot.GD.Print(formattedLog);
 #elif !DOT_NET
                         Debug.Log(formattedLog);
 #elif !XAMARIN
@@ -1357,7 +1357,9 @@ using System.Globalization;
 
             if (error != null)
             {
-#if !(DOT_NET || GODOT)
+#if GODOT
+                Godot.GD.Print("ERROR | Failed to initialize brainCloud - " + error);
+#elif !DOT_NET
                 Debug.LogError("ERROR | Failed to initialize brainCloud - " + error);
 #elif !XAMARIN
                 Console.WriteLine("ERROR | Failed to initialize brainCloud - " + error);

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
@@ -2525,12 +2525,18 @@ public class BrainCloudWrapper
     private void SaveData()
     {
 #if DOT_NET || GODOT
-        string prefix = string.IsNullOrEmpty(WrapperName).Equals("") ? "" : WrapperName + ".";
+        string prefix = string.IsNullOrEmpty(WrapperName) ? "" : WrapperName + ".";
         string fileName = prefix + WrapperData.FileName;
+        string path = fileName;
+
+    #if GODOT
+        string userDir = Godot.OS.GetUserDataDir();
+        path = userDir + "/" + fileName;
+    #endif
 
         IsolatedStorageFile isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Assembly, null, null);
 
-        using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(fileName, FileMode.OpenOrCreate, isoStore))
+        using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(path, FileMode.OpenOrCreate, isoStore))
         {
             using (StreamWriter writer = new StreamWriter(isoStream))
             {
@@ -2552,14 +2558,20 @@ public class BrainCloudWrapper
 #if DOT_NET || GODOT
         string prefix = string.IsNullOrEmpty(WrapperName) ? "" : WrapperName + ".";
         string fileName = prefix + WrapperData.FileName;
+        string path = fileName;
+
+    #if GODOT
+        string userDir = Godot.OS.GetUserDataDir();
+        path = userDir + "/" + fileName;
+    #endif
 
         IsolatedStorageFile isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Assembly, null, null);
 
-        if (isoStore.FileExists(fileName))
+        if (isoStore.FileExists(path))
         {
             string file;
 
-            using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(fileName, FileMode.Open, isoStore))
+            using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(path, FileMode.Open, isoStore))
             {
                 using (StreamReader reader = new StreamReader(isoStream))
                 {

--- a/BrainCloudClient/Assets/BrainCloud/UnityWebSocketsForWebGL/WebSocketSharp/AssemblyInfo.cs
+++ b/BrainCloudClient/Assets/BrainCloud/UnityWebSocketsForWebGL/WebSocketSharp/AssemblyInfo.cs
@@ -4,6 +4,8 @@ using System.Runtime.CompilerServices;
 // Information about this assembly is defined by the following attributes. 
 // Change them to the values specific to your project.
 
+#if !GODOT
+
 [assembly: AssemblyTitle("websocket-sharp")]
 [assembly: AssemblyDescription("A C# implementation of the WebSocket protocol client and server")]
 [assembly: AssemblyConfiguration("")]
@@ -17,10 +19,8 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-#if !(DOT_NET || GODOT)
-[assembly: AssemblyVersion("1.0.2")] //.* does not support unity 2020 deterministic builds. The .* here is not even necessary for us to have either. 
-#else 
 [assembly: AssemblyVersion("1.0.2")]
+
 #endif
 
 // The following attributes are used to specify the signing key for the assembly, 


### PR DESCRIPTION
- Fixed BrainCloudWrapper saving and loading

- Fixed three compiler errors in Godot
1. AssemblyInfo.cs is now ignored entirely on Godot as it causes several duplicate symbols
2. Missing semicolon in BrainCloudClient when setting the clientLib string
3. GD.Print was not using the Godot namespace when being invoked

