### PR TITLE
Fixes for UWP and WebGL

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAppStore.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAppStore.cs
@@ -188,8 +188,19 @@ using System;
             Dictionary<string, object> data = new Dictionary<string, object>();
             data[OperationParam.AppStoreServiceStoreId.Value] = storeId;
 
-            var receiptData = JsonReader.Deserialize<Dictionary<string, object>>(receiptJson);
-            data[OperationParam.AppStoreServiceReceiptData.Value] = receiptData;
+            Dictionary<string, object> receiptData;
+
+            try
+            {
+                receiptData = JsonReader.Deserialize<Dictionary<string, object>>(receiptJson);
+                data[OperationParam.AppStoreServiceReceiptData.Value] = receiptData;
+            }
+            catch (Exception ex)
+            {
+                //not a valid json string, pass it as string directly
+                data[OperationParam.AppStoreServiceReceiptData.Value] = receiptJson;
+            }
+            
 
             ServerCallback callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
             ServerCall sc = new ServerCall(ServiceName.AppStore, ServiceOperation.VerifyPurchase, data, callback);

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/RegionLocale.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/RegionLocale.cs
@@ -13,7 +13,9 @@ namespace BrainCloud
 #endif
 #if (!(DOT_NET || GODOT))
     using UnityEngine;
-
+#endif
+#if ENABLE_WINMD_SUPPORT
+    using Windows.Globalization;
 #endif
 
     public class RegionLocale

--- a/BrainCloudClient/Assets/BrainCloud/UnityWebSocketsForWebGL/websocket-native.jslib
+++ b/BrainCloudClient/Assets/BrainCloud/UnityWebSocketsForWebGL/websocket-native.jslib
@@ -1,6 +1,6 @@
 var NativeWebSocket = {
 
-    $WebSocketInstances: [],
+    $WebSocketInstances: {},
 
     BrainCloudSocketCreate: function (url, id) {
     	console.log("[NativeWebSocket] Socket create: " + id);


### PR DESCRIPTION
- Fixed build issue on UWP due to a missing <using namespace> statement
- Fixed issue with WebSocket in WebGL on iOS where browser resets due to running out of memory.