### PR TITLE
Nick/bcloud 9326

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAuthentication.cs
@@ -63,6 +63,19 @@ using BrainCloud.JsonFx.Json;
         }
 
         /// <summary>
+        /// Gets the brainCloud server version.
+        /// </summary>
+        public void getServerVersion(SuccessCallback success = null, FailureCallback failure = null)
+        {
+            Dictionary<string, object> data = new Dictionary<string, object>();
+            data[OperationParam.AuthenticateServiceAuthenticateGameId.Value] = _client.AppId;
+
+            ServerCallback callback = BrainCloudClient.CreateServerCallback(success, failure);
+            ServerCall sc = new ServerCall(ServiceName.Authenticate, ServiceOperation.GetServerVersion, data, callback);
+            _client.SendRequest(sc);
+        }
+
+        /// <summary>
         /// Authenticate a user anonymously with brainCloud - used for apps that don't want to bother
         /// the user to login, or for users who are sensitive to their privacy
         /// </summary>

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1566,7 +1566,8 @@ using UnityEngine.Experimental.Networking;
                             operation.Equals(ServiceOperation.ResetEmailPassword.Value) ||
                             operation.Equals(ServiceOperation.ResetEmailPasswordAdvanced.Value) ||
                             operation.Equals(ServiceOperation.ResetUniversalIdPassword.Value) ||
-                            operation.Equals(ServiceOperation.ResetUniversalIdPasswordAdvanced.Value))
+                            operation.Equals(ServiceOperation.ResetUniversalIdPasswordAdvanced.Value) ||
+                            operation.Equals(ServiceOperation.GetServerVersion.Value))
                         {
                             isAuth = true;
                         }
@@ -1955,12 +1956,13 @@ using UnityEngine.Experimental.Networking;
             }
 
             response = _activeRequest.WebRequest.downloadHandler.text;
-            
+
             if (response.Contains("Security violation 47") ||
                 response.StartsWith("<"))
             {
                 Debug.LogWarning("Please re-select app in brainCloud settings, something went wrong"); 
             }
+
 #elif DOT_NET || GODOT
             response = _activeRequest.DotNetResponseString;
 #endif

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/ServiceOperation.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/ServiceOperation.cs
@@ -18,6 +18,7 @@ using System;
         public static readonly ServiceOperation Attach = new ServiceOperation("ATTACH");
         public static readonly ServiceOperation Merge = new ServiceOperation("MERGE");
         public static readonly ServiceOperation Detach = new ServiceOperation("DETACH");
+        public static readonly ServiceOperation GetServerVersion = new ServiceOperation("GET_SERVER_VERSION");
         public static readonly ServiceOperation ResetEmailPassword = new ServiceOperation("RESET_EMAIL_PASSWORD");
         public static readonly ServiceOperation ResetEmailPasswordWithExpiry = new ServiceOperation("RESET_EMAIL_PASSWORD_WITH_EXPIRY");
         public static readonly ServiceOperation ResetEmailPasswordAdvanced = new ServiceOperation("RESET_EMAIL_PASSWORD_ADVANCED");

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
@@ -16,7 +16,23 @@ namespace Tests.PlayMode
         private string _universalID = "UserA_CS-1730261329";
         private string _password = "12345";
         private int additionalCalls = 0;
-        
+
+        [UnityTest]
+        public IEnumerator TestGetServerVersion()
+        {
+            string anonId = _tc.bcWrapper.Client.AuthenticationService.GenerateAnonymousId();
+            _tc.bcWrapper.Client.AuthenticationService.AuthenticateAnonymous
+            (
+                anonId,
+                true,
+                _tc.ApiSuccess,
+                _tc.ApiError
+            );
+
+            _tc.bcWrapper.Client.AuthenticationService.getServerVersion(_tc.ApiSuccess, _tc.ApiError);
+            yield return _tc.StartCoroutine(_tc.Run(2));
+        }
+
         [UnityTest]
         public IEnumerator TestAuthenticateSpam()
         {

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestAuthenticate.cs
@@ -20,17 +20,8 @@ namespace Tests.PlayMode
         [UnityTest]
         public IEnumerator TestGetServerVersion()
         {
-            string anonId = _tc.bcWrapper.Client.AuthenticationService.GenerateAnonymousId();
-            _tc.bcWrapper.Client.AuthenticationService.AuthenticateAnonymous
-            (
-                anonId,
-                true,
-                _tc.ApiSuccess,
-                _tc.ApiError
-            );
-
             _tc.bcWrapper.Client.AuthenticationService.getServerVersion(_tc.ApiSuccess, _tc.ApiError);
-            yield return _tc.StartCoroutine(_tc.Run(2));
+            yield return _tc.StartCoroutine(_tc.Run());
         }
 
         [UnityTest]


### PR DESCRIPTION
Added GetServerVersion function and made sure it works when there is no authenticated session
Added test for this function in the Authentication tests

This is a log of a successful test run:

```
TestGetServerVersion (0.405s)
---
Setting Up......
Running...
14:50:47.932 #BCC SENDING REQUEST
14:50:47.949 #BCC REQUEST - 2025-01-14 2:50:47 PM
{"packetId":0,"sessionId":"","gameId":"20001","messages":[{"service":"authenticationV2","operation":"GET_SERVER_VERSION","data":{"gameId":"20001"}}]}
14:50:48.259 #BCC RESPONSE - 2025-01-14 2:50:48 PM
{"packetId":0,"responses":[{"data":{"serverVersion":"D5.5.0-1862"},"status":200}]}
Response Received
Attempting different deserialization....
Tearing Down....
Success Count: 1
Fail Count: 0
```