### PR TITLE
BCLOUD-9474

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPushNotification.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPushNotification.cs
@@ -42,31 +42,35 @@ using System;
         /// <param name="cbObject">
         /// The callback object
         /// </param>
-        public bool RegisterPushNotificationDeviceToken(
+        public void RegisterPushNotificationDeviceToken(
             byte[] token,
             SuccessCallback success = null,
             FailureCallback failure = null,
             object cbObject = null)
         {
-
-            if (token != null || token.Length < 1)
+            if (token == null || token.Length < 1)
             {
-                byte[] tokenData = token;
+                if (failure != null)
+                {
+                    int statusCode = 400;
+                    string errorJson = "{\"status\":" + statusCode +
+                                       ",\"reason_code\":" + INVALID_DEVICE_TOKEN +
+                                       ",\"message\":\"Device token is null or empty.\"}";
 
-                Platform platform = Platform.FromUnityRuntime();
-                string hexToken = BitConverter.ToString(tokenData).Replace("-","").ToLower();
-                RegisterPushNotificationDeviceToken(platform,
-                        hexToken,
-                        success,
-                        failure,
-                        cbObject);
-                return true;
+                    failure(statusCode, INVALID_DEVICE_TOKEN, errorJson, cbObject);
+                }
+                return;
             }
-            // there was an error
-            else
-            {
-                return false;
-            }
+            
+            byte[] tokenData = token;
+
+            Platform platform = Platform.FromUnityRuntime();
+            string hexToken = BitConverter.ToString(tokenData).Replace("-", "").ToLower();
+            RegisterPushNotificationDeviceToken(platform,
+                    hexToken,
+                    success,
+                    failure,
+                    cbObject);
         }
 
         /// <summary>
@@ -85,27 +89,32 @@ using System;
         /// <param name="cbObject">
         /// The callback object
         /// </param>
-        public bool RegisterPushNotificationDeviceToken(
+        public void RegisterPushNotificationDeviceToken(
             string token,
             SuccessCallback success = null,
             FailureCallback failure = null,
             object cbObject = null)
         {
-            if (token != null || token.Length < 1)
+            if (string.IsNullOrEmpty(token))
             {
-                Platform platform = Platform.FromUnityRuntime();
-                RegisterPushNotificationDeviceToken(platform,
-                        token,
-                        success,
-                        failure,
-                        cbObject);
-                return true;
+                if (failure != null)
+                {
+                    int statusCode = 400;
+                    string errorJson = "{\"status\":" + statusCode +
+                                       ",\"reason_code\":" + INVALID_DEVICE_TOKEN +
+                                       ",\"message\":\"Device token is null or empty.\"}";
+
+                    failure(statusCode, INVALID_DEVICE_TOKEN, errorJson, cbObject);
+                }
+                return;
             }
-            // there was an error
-            else
-            {
-                return false;
-            }
+
+            Platform platform = Platform.FromUnityRuntime();
+            RegisterPushNotificationDeviceToken(platform,
+                    token,
+                    success,
+                    failure,
+                    cbObject);
         }
 #endif
 
@@ -196,6 +205,22 @@ using System;
             FailureCallback failure = null,
             object cbObject = null)
         {
+            if (string.IsNullOrEmpty(token))
+            {
+                if (failure != null)
+                {
+                    int statusCode = 400; // Bad Request
+                    int reasonCode = INVALID_DEVICE_TOKEN; // Custom code for "Invalid Token"
+                    string errorJson = "{\"status\":"+statusCode+
+                                        ",\"reason_code\":" +INVALID_DEVICE_TOKEN+
+                                        ",\"message\":\"Device token is null or empty.\"}";
+                    
+                    failure(statusCode, reasonCode, errorJson, cbObject);
+                }
+
+                return;
+            }
+            
             string devicePlatform = platform.ToString();
             Dictionary<string, object> data = new Dictionary<string, object>();
             data[OperationParam.PushNotificationRegisterParamDeviceType.Value] = devicePlatform;

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPushNotification.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudPushNotification.cs
@@ -55,7 +55,7 @@ using System;
                     int statusCode = 400;
                     string errorJson = "{\"status\":" + statusCode +
                                        ",\"reason_code\":" + INVALID_DEVICE_TOKEN +
-                                       ",\"message\":\"Device token is null or empty.\"}";
+                                       ",\"message\":\"Invalid device token: " + token + " \"}";
 
                     failure(statusCode, INVALID_DEVICE_TOKEN, errorJson, cbObject);
                 }
@@ -102,7 +102,7 @@ using System;
                     int statusCode = 400;
                     string errorJson = "{\"status\":" + statusCode +
                                        ",\"reason_code\":" + INVALID_DEVICE_TOKEN +
-                                       ",\"message\":\"Device token is null or empty.\"}";
+                                       ",\"message\":\"Invalid device token: " + token + " \"}";
 
                     failure(statusCode, INVALID_DEVICE_TOKEN, errorJson, cbObject);
                 }
@@ -213,7 +213,7 @@ using System;
                     int reasonCode = INVALID_DEVICE_TOKEN; // Custom code for "Invalid Token"
                     string errorJson = "{\"status\":"+statusCode+
                                         ",\"reason_code\":" +INVALID_DEVICE_TOKEN+
-                                        ",\"message\":\"Device token is null or empty.\"}";
+                                       ",\"message\":\"Invalid device token: " + token + " \"}";
                     
                     failure(statusCode, reasonCode, errorJson, cbObject);
                 }


### PR DESCRIPTION
Client Library update - Update the client libs to Catch the case when the app requests notifications and the user denies it, resulting in an "empty token" being saved into the place that stores the notification token - Unity/C#