### PR TITLE
Bcloud 10093 long session

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudWrapper.cs
@@ -2082,7 +2082,13 @@ public class BrainCloudWrapper
     {
         return GetStoredProfileId() != String.Empty && GetStoredAnonymousId() != String.Empty;
     }
-        
+
+    public void EnableLongSession(bool enabled)
+    {
+        InitializeIdentity(true);
+        Client.Comms.EnableLongSession(enabled);
+    }
+
     /// <summary>
     /// Logs user out of server.
     /// </summary>
@@ -2108,7 +2114,7 @@ public class BrainCloudWrapper
         FailureCallback failure = null,
         object cbObject = null)
     {
-        if(forgetUser)
+        if (forgetUser)
         {
             ResetStoredProfileId();
         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -1302,7 +1302,7 @@ using UnityEngine.Experimental.Networking;
                                 _serviceCallsWaiting.AddRange(otherServiceCallsInProgress);
                             }
 
-                            // Next Update loop will take care of things
+                            // Next Update loop will handle the re-authenticate request/response
                             return;
                         };
 
@@ -1318,8 +1318,7 @@ using UnityEngine.Experimental.Networking;
                         // Attempt to re-authenticate
                         _clientRef.AuthenticationService.AuthenticateAnonymous(false, successCallback, failureCallback);
 
-                        // TODO: need this?
-                        // return; // Do not process callbacks for this call, they be handled async inline above 
+                        return; 
                     }
 
                     if (reasonCode == ReasonCodes.PLAYER_SESSION_EXPIRED

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -48,9 +48,19 @@ using UnityEngine.Experimental.Networking;
     internal sealed class BrainCloudComms
     {
         /// <summary>
+        /// Enables automatic re-authentication when the user's session expires
+        /// </summary>
+        public bool LongSessionEnabled { get; private set; } = false;
+
+        public void EnableLongSession(bool enabled)
+        {
+            LongSessionEnabled = enabled;
+        }
+
+        /// <summary>
         ///Compress bundles sent from the client to the server for faster sending of large bundles.
         /// </summary>
-        public bool SupportsCompression {get; private set;} = true;
+        public bool SupportsCompression { get; private set; } = true;
         
         public void EnableCompression(bool compress)
         {
@@ -1268,13 +1278,57 @@ using UnityEngine.Experimental.Networking;
                         errorJson = SerializeJson(response);
                     }
 
+                    // If the authenticated session has expired, and long session is enabled, attempt to re-authenticate and retry lost call(s)
+                    if (reasonCode == ReasonCodes.PLAYER_SESSION_EXPIRED && LongSessionEnabled && operation != ServiceOperation.Authenticate.Value && _isAuthenticated)
+                    {
+                        // Save the call that failed
+                        ServerCall expiredServerCall = sc;
+                        var otherServiceCallsInProgress = new List<ServerCall>(_serviceCallsInProgress);
+                        _serviceCallsInProgress.Clear();
+                        _clientRef.Log("Session expired. Attempting reconnect . . .");
+                        _packetId = 0;
+
+                        // Retry failed/missed call(s) on successful re-authentication
+                        SuccessCallback successCallback = (response, cbObject) =>
+                        {
+                            _clientRef.Log(string.Format("Success | {0}", response));
+
+                            if (expiredServerCall != null)
+                            {
+                                // Re-queue the call that failed...
+                                _serviceCallsWaiting.Add(expiredServerCall);
+
+                                // ...and any other calls in the bundle as they will fail too
+                                _serviceCallsWaiting.AddRange(otherServiceCallsInProgress);
+                            }
+
+                            // Next Update loop will take care of things
+                            return;
+                        };
+
+                        FailureCallback failureCallback = (status, code, error, cbObject) =>
+                        {
+                            _clientRef.Log(string.Format("Long session re-authentication failed. | {0}  {1}  {2}", status, code, error));
+
+                            LongSessionEnabled = false;
+
+                            expiredServerCall?.GetCallback()?.OnErrorCallback(status, code, error);
+                        };
+
+                        // Attempt to re-authenticate
+                        _clientRef.AuthenticationService.AuthenticateAnonymous(false, successCallback, failureCallback);
+
+                        // TODO: need this?
+                        // return; // Do not process callbacks for this call, they be handled async inline above 
+                    }
+
                     if (reasonCode == ReasonCodes.PLAYER_SESSION_EXPIRED
                         || reasonCode == ReasonCodes.NO_SESSION
                         || reasonCode == ReasonCodes.PLAYER_SESSION_LOGGED_OUT)
                     {
                         _isAuthenticated = false;
                         SessionID = "";
-                        
+
                         if (_clientRef.LoggingEnabled)
                         {
                             _clientRef.Log("Received session expired or not found, need to re-authenticate");

--- a/BrainCloudClient/tests/TestWrapper.cs
+++ b/BrainCloudClient/tests/TestWrapper.cs
@@ -212,8 +212,6 @@ namespace BrainCloudTests
             userWrapper.ScriptService.RunScript("LogoutSession", jsonData, userTr.ApiSuccess, userTr.ApiError);
             userTr.Run();
 
-            //Thread.Sleep(5000);
-
             // Verify session is no longer active (this should not be successful)
             _bc.IdentityService.GetIdentities(tr.ApiSuccess, tr.ApiError);
             tr.RunExpectFail();
@@ -253,8 +251,6 @@ namespace BrainCloudTests
             // Run LogoutSession script to end session 
             userWrapper.ScriptService.RunScript("LogoutSession", jsonData, userTr.ApiSuccess, userTr.ApiError);
             userTr.Run();
-
-            //Thread.Sleep(5000);
 
             // Verify session is no longer active (this should not be successful)
             _bc.IdentityService.GetIdentities(tr.ApiSuccess, tr.ApiError);


### PR DESCRIPTION
- EnableLongSession allows the user to decide if automatic re-authentication should happen upon session expiry