### PR TITLE
BCLOUD-10993 Unit Test for CachePurchaseContext

### DIFF
--- a/BrainCloudClient/tests/TestAppStore.cs
+++ b/BrainCloudClient/tests/TestAppStore.cs
@@ -11,7 +11,7 @@ namespace BrainCloudTests
     public class TestAppStore : TestFixtureBase
     {
         [Test]
-        public void TestVerifyPurchase()
+        public void TestCachePurchaseContext()
         {
             TestResult tr = new TestResult(_bc);
 


### PR DESCRIPTION
[BCLOUD-10987](https://bitheads.atlassian.net/browse/BCLOUD-10987)

This is just adding a unit test for CachePurchaseContext, which was added in [PR 330](https://github.com/getbraincloud/braincloud-csharp/pull/330). The test is expected to fail.