### PR TITLE
[BCLOUD-6317] Add Mock store CachePurchasePayloadContext then VerifyPurchase for CSharp and Unity

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAppStore.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAppStore.cs
@@ -157,7 +157,7 @@ using System;
         /// </summary>
         /// <remarks>
         /// Service Name - AppStore
-        /// Service Operation - CachePurchasePayloadContext
+        /// Service Operation - CACHE_PURCHASE_PAYLOAD_CONTEXT
         /// </remarks>
         /// <param name="storeId">
         /// The store storeId. Valid stores are:

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestAppStore.cs.meta
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestAppStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42bd59b710e7d144ab770db6829959c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BrainCloudClient/Assets/Tests/PlayMode/TestFixtureBase.cs
+++ b/BrainCloudClient/Assets/Tests/PlayMode/TestFixtureBase.cs
@@ -59,7 +59,7 @@ namespace Tests.PlayMode
                 _tc.bcWrapper.Client.DeregisterFileUploadCallback();
                 _tc.bcWrapper.Client.DeregisterFileUploadCallback();
                 _tc.bcWrapper.Client.DeregisterGlobalErrorCallback();
-                _tc.bcWrapper.Client.DeregisterNetworkErrorCallback();                
+                _tc.bcWrapper.Client.DeregisterNetworkErrorCallback();
                 _tc.CleanUp();
                 Destroy(_tc.bcWrapper);
             }

--- a/BrainCloudClient/ProjectSettings/EditorSettings.asset
+++ b/BrainCloudClient/ProjectSettings/EditorSettings.asset
@@ -3,20 +3,45 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
-  m_ExternalVersionControlSupport: Hidden Meta Files
+  serializedVersion: 12
   m_SerializationMode: 2
-  m_LineEndingsForNewScripts: 1
+  m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 0
+  m_PrefabRegularEnvironment: {fileID: 0}
+  m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
+  m_SpritePackerCacheSize: 10
   m_SpritePackerPaddingPower: 1
+  m_Bc7TextureCompressor: 0
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref
   m_ProjectGenerationRootNamespace: 
-  m_UserGeneratedProjectSuffix: 
-  m_CollabEditorSettings:
-    inProgressEnabled: 1
+  m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
+  m_EnableEditorAsyncCPUTextureLoading: 0
+  m_AsyncShaderCompilation: 1
+  m_PrefabModeAllowAutoSave: 1
+  m_EnterPlayModeOptionsEnabled: 0
+  m_EnterPlayModeOptions: 3
+  m_GameObjectNamingDigits: 1
+  m_GameObjectNamingScheme: 0
+  m_AssetNamingUsesSpace: 1
+  m_InspectorUseIMGUIDefaultInspector: 0
+  m_UseLegacyProbeSampleCount: 1
+  m_SerializeInlineMappingsOnOneLine: 0
+  m_DisableCookiesInLightmapper: 1
+  m_AssetPipelineMode: 1
+  m_RefreshImportMode: 0
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1
+  m_CacheServerEnableAuth: 0
+  m_CacheServerEnableTls: 0
+  m_CacheServerValidationMode: 2
+  m_CacheServerDownloadBatchSize: 128
+  m_EnableEnlightenBakedGI: 0

--- a/BrainCloudClient/ProjectSettings/SceneTemplateSettings.json
+++ b/BrainCloudClient/ProjectSettings/SceneTemplateSettings.json
@@ -4,164 +4,123 @@
         {
             "userAdded": false,
             "type": "UnityEngine.AnimationClip",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.Animations.AnimatorController",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.AnimatorOverrideController",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.Audio.AudioMixerController",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.ComputeShader",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Cubemap",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.GameObject",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.LightingDataAsset",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": false
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.LightingSettings",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Material",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.MonoScript",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.PhysicMaterial",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial",
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.PhysicsMaterial2D",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Rendering.VolumeProfile",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.SceneAsset",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": false
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Shader",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.ShaderVariantCollection",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Texture",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Texture2D",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Timeline.TimelineAsset",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         }
     ],
     "defaultDependencyTypeInfo": {
         "userAdded": false,
         "type": "<default_scene_template_dependencies>",
-        "ignore": false,
-        "defaultInstantiationMode": 1,
-        "supportsModification": true
+        "defaultInstantiationMode": 1
     },
     "newSceneOverride": 0
 }

--- a/BrainCloudClient/tests/TestAppStore.cs
+++ b/BrainCloudClient/tests/TestAppStore.cs
@@ -194,7 +194,11 @@ namespace BrainCloudTests
 
             if (response.ContainsKey("errorMessage"))
             {
+#if DOT_NET
+                Console.WriteLine(response["errorMessage"]);
+#else
                 Debug.LogError(response["errorMessage"]);
+#endif
             }
 
             Assert.That(response, Contains.Key("success"), "VerifyPurchase response did not contain a success key");


### PR DESCRIPTION
[BCLOUD-6317](https://bitheads.atlassian.net/browse/BCLOUD-6317)

Added new **AppStore** unit test to test an average user purchasing flow. This will `GetSalesInventory` to grab a product and the data required to then `CachePurchasePayloadContext` and then it constructs a fake `receiptData` for the mock store to run a `VerifyPurchase` mock store script as Cloud Code.

Going to need someone to open the C# project to make sure there's no errors; had to go in a bit blind because my project wasn't loading the NUnit dependencies so they all show as error on my end.