### PR TITLE
ServiceName, ServiceOperation, and OperationParams to use Modern C# Features

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAppStore.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudAppStore.cs
@@ -249,7 +249,7 @@ using System;
                 receiptData = JsonReader.Deserialize<Dictionary<string, object>>(receiptJson);
                 data[OperationParam.AppStoreServiceReceiptData.Value] = receiptData;
             }
-            catch (Exception ex)
+            catch
             {
                 //not a valid json string, pass it as string directly
                 data[OperationParam.AppStoreServiceReceiptData.Value] = receiptJson;

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/OperationParam.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/OperationParam.cs
@@ -6,602 +6,656 @@
 
 namespace BrainCloud
 {
-    public sealed class OperationParam
+    public struct OperationParam : System.IEquatable<OperationParam>, System.IComparable<OperationParam>
     {
+        #region brainCloud Operation Parameters
+
         //Push Notification Service - Register Params
-        public static readonly OperationParam PushNotificationRegisterParamDeviceType = new OperationParam("deviceType");
-        public static readonly OperationParam PushNotificationRegisterParamDeviceToken = new OperationParam("deviceToken");
+        public static readonly OperationParam PushNotificationRegisterParamDeviceType = "deviceType";
+        public static readonly OperationParam PushNotificationRegisterParamDeviceToken = "deviceToken";
 
         //Push Notification Service - Send Params
-        public static readonly OperationParam PushNotificationSendParamToPlayerId = new OperationParam("toPlayerId");
-        public static readonly OperationParam PushNotificationSendParamProfileId = new OperationParam("profileId");
-        public static readonly OperationParam PushNotificationSendParamMessage = new OperationParam("message");
-        public static readonly OperationParam PushNotificationSendParamNotificationTemplateId = new OperationParam("notificationTemplateId");
-        public static readonly OperationParam PushNotificationSendParamSubstitutions = new OperationParam("substitutions");
-        public static readonly OperationParam PushNotificationSendParamProfileIds = new OperationParam("profileIds");
+        public static readonly OperationParam PushNotificationSendParamToPlayerId = "toPlayerId";
+        public static readonly OperationParam PushNotificationSendParamProfileId = "profileId";
+        public static readonly OperationParam PushNotificationSendParamMessage = "message";
+        public static readonly OperationParam PushNotificationSendParamNotificationTemplateId = "notificationTemplateId";
+        public static readonly OperationParam PushNotificationSendParamSubstitutions = "substitutions";
+        public static readonly OperationParam PushNotificationSendParamProfileIds = "profileIds";
 
-        public static readonly OperationParam PushNotificationSendParamFcmContent = new OperationParam("fcmContent");
-        public static readonly OperationParam PushNotificationSendParamIosContent = new OperationParam("iosContent");
-        public static readonly OperationParam PushNotificationSendParamFacebookContent = new OperationParam("facebookContent");
+        public static readonly OperationParam PushNotificationSendParamFcmContent = "fcmContent";
+        public static readonly OperationParam PushNotificationSendParamIosContent = "iosContent";
+        public static readonly OperationParam PushNotificationSendParamFacebookContent = "facebookContent";
 
 
-        public static readonly OperationParam AlertContent = new OperationParam("alertContent");
-        public static readonly OperationParam CustomData = new OperationParam("customData");
+        public static readonly OperationParam AlertContent = "alertContent";
+        public static readonly OperationParam CustomData = "customData";
 
-        public static readonly OperationParam StartDateUTC = new OperationParam("startDateUTC");
-        public static readonly OperationParam MinutesFromNow = new OperationParam("minutesFromNow");
+        public static readonly OperationParam StartDateUTC = "startDateUTC";
+        public static readonly OperationParam MinutesFromNow = "minutesFromNow";
 
         // Twitter Service - Verify Params
-        public static readonly OperationParam TwitterServiceVerifyToken = new OperationParam("token");
-        public static readonly OperationParam TwitterServiceVerifyVerifier = new OperationParam("verifier");
+        public static readonly OperationParam TwitterServiceVerifyToken = "token";
+        public static readonly OperationParam TwitterServiceVerifyVerifier = "verifier";
 
         // Twitter Service - Tweet Params
-        public static readonly OperationParam TwitterServiceTweetToken = new OperationParam("token");
-        public static readonly OperationParam TwitterServiceTweetSecret = new OperationParam("secret");
-        public static readonly OperationParam TwitterServiceTweetTweet = new OperationParam("tweet");
-        public static readonly OperationParam TwitterServiceTweetPic = new OperationParam("pic");
+        public static readonly OperationParam TwitterServiceTweetToken = "token";
+        public static readonly OperationParam TwitterServiceTweetSecret = "secret";
+        public static readonly OperationParam TwitterServiceTweetTweet = "tweet";
+        public static readonly OperationParam TwitterServiceTweetPic = "pic";
 
-        public static readonly OperationParam BlockChainConfig = new OperationParam("blockchainConfig");
-        public static readonly OperationParam BlockChainIntegrationId = new OperationParam("integrationId");
-        public static readonly OperationParam BlockChainContext = new OperationParam("contextJson");
-        public static readonly OperationParam PublicKey = new OperationParam("publicKey");
-
-        // Authenticate Service - Authenticate Params
-        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationType = new OperationParam("authenticationType");
-        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationToken = new OperationParam("authenticationToken");
-        public static readonly OperationParam AuthenticateServiceAuthenticateExternalId = new OperationParam("externalId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateUniversalId = new OperationParam("universalId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateGameId = new OperationParam("gameId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateDeviceId = new OperationParam("deviceId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateForceMergeFlag = new OperationParam("forceMergeFlag");
-        public static readonly OperationParam AuthenticateServiceAuthenticateReleasePlatform = new OperationParam("releasePlatform");
-        public static readonly OperationParam AuthenticateServiceAuthenticateGameVersion = new OperationParam("gameVersion");
-        public static readonly OperationParam AuthenticateServiceAuthenticateBrainCloudVersion = new OperationParam("clientLibVersion");
-        public static readonly OperationParam AuthenticateServiceAuthenticateExternalAuthName = new OperationParam("externalAuthName");
-        public static readonly OperationParam AuthenticateServiceAuthenticateEmailAddress = new OperationParam("emailAddress");
-        public static readonly OperationParam AuthenticateServiceAuthenticateServiceParams = new OperationParam("serviceParams");
-        public static readonly OperationParam AuthenticateServiceAuthenticateTokenTtlInMinutes = new OperationParam("tokenTtlInMinutes");
-
-        public static readonly OperationParam AuthenticateServiceAuthenticateLevelName = new OperationParam("levelName");
-        public static readonly OperationParam AuthenticateServiceAuthenticatePeerCode = new OperationParam("peerCode");
-
-        public static readonly OperationParam AuthenticateServiceAuthenticateCountryCode = new OperationParam("countryCode");
-        public static readonly OperationParam AuthenticateServiceAuthenticateLanguageCode = new OperationParam("languageCode");
-        public static readonly OperationParam AuthenticateServiceAuthenticateTimeZoneOffset = new OperationParam("timeZoneOffset");
-
-        public static readonly OperationParam AuthenticateServiceAuthenticateAuthUpgradeID = new OperationParam("upgradeAppId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateAnonymousId = new OperationParam("anonymousId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateProfileId = new OperationParam("profileId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateForceCreate = new OperationParam("forceCreate");
-        public static readonly OperationParam AuthenticateServiceAuthenticateCompressResponses = new OperationParam("compressResponses");
-        public static readonly OperationParam AuthenticateServicePlayerSessionExpiry = new OperationParam("playerSessionExpiry");
-        public static readonly OperationParam AuthenticateServiceAuthenticateExtraJson = new OperationParam("extraJson");
+        public static readonly OperationParam BlockChainConfig = "blockchainConfig";
+        public static readonly OperationParam BlockChainIntegrationId = "integrationId";
+        public static readonly OperationParam BlockChainContext = "contextJson";
+        public static readonly OperationParam PublicKey = "publicKey";
 
         // Authenticate Service - Authenticate Params
-        public static readonly OperationParam IdentityServiceExternalId = new OperationParam("externalId");
-        public static readonly OperationParam IdentityServiceAuthenticationType = new OperationParam("authenticationType");
-        public static readonly OperationParam IdentityServiceConfirmAnonymous = new OperationParam("confirmAnonymous");
+        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationType = "authenticationType";
+        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationToken = "authenticationToken";
+        public static readonly OperationParam AuthenticateServiceAuthenticateExternalId = "externalId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateUniversalId = "universalId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateGameId = "gameId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateDeviceId = "deviceId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateForceMergeFlag = "forceMergeFlag";
+        public static readonly OperationParam AuthenticateServiceAuthenticateReleasePlatform = "releasePlatform";
+        public static readonly OperationParam AuthenticateServiceAuthenticateGameVersion = "gameVersion";
+        public static readonly OperationParam AuthenticateServiceAuthenticateBrainCloudVersion = "clientLibVersion";
+        public static readonly OperationParam AuthenticateServiceAuthenticateExternalAuthName = "externalAuthName";
+        public static readonly OperationParam AuthenticateServiceAuthenticateEmailAddress = "emailAddress";
+        public static readonly OperationParam AuthenticateServiceAuthenticateServiceParams = "serviceParams";
+        public static readonly OperationParam AuthenticateServiceAuthenticateTokenTtlInMinutes = "tokenTtlInMinutes";
+
+        public static readonly OperationParam AuthenticateServiceAuthenticateLevelName = "levelName";
+        public static readonly OperationParam AuthenticateServiceAuthenticatePeerCode = "peerCode";
+
+        public static readonly OperationParam AuthenticateServiceAuthenticateCountryCode = "countryCode";
+        public static readonly OperationParam AuthenticateServiceAuthenticateLanguageCode = "languageCode";
+        public static readonly OperationParam AuthenticateServiceAuthenticateTimeZoneOffset = "timeZoneOffset";
+
+        public static readonly OperationParam AuthenticateServiceAuthenticateAuthUpgradeID = "upgradeAppId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateAnonymousId = "anonymousId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateProfileId = "profileId";
+        public static readonly OperationParam AuthenticateServiceAuthenticateForceCreate = "forceCreate";
+        public static readonly OperationParam AuthenticateServiceAuthenticateCompressResponses = "compressResponses";
+        public static readonly OperationParam AuthenticateServicePlayerSessionExpiry = "playerSessionExpiry";
+        public static readonly OperationParam AuthenticateServiceAuthenticateExtraJson = "extraJson";
+
+        // Authenticate Service - Authenticate Params
+        public static readonly OperationParam IdentityServiceExternalId = "externalId";
+        public static readonly OperationParam IdentityServiceAuthenticationType = "authenticationType";
+        public static readonly OperationParam IdentityServiceConfirmAnonymous = "confirmAnonymous";
         
-        public static readonly OperationParam IdentityServiceOldEmailAddress = new OperationParam("oldEmailAddress");
-        public static readonly OperationParam IdentityServiceNewEmailAddress = new OperationParam("newEmailAddress");
-        public static readonly OperationParam IdentityServiceUpdateContactEmail = new OperationParam("updateContactEmail");
+        public static readonly OperationParam IdentityServiceOldEmailAddress = "oldEmailAddress";
+        public static readonly OperationParam IdentityServiceNewEmailAddress = "newEmailAddress";
+        public static readonly OperationParam IdentityServiceUpdateContactEmail = "updateContactEmail";
 
 
         // Peer
-        public static readonly OperationParam Peer = new OperationParam("peer");
+        public static readonly OperationParam Peer = "peer";
 
         // Entity Service 
-        public static readonly OperationParam EntityServiceEntityId = new OperationParam("entityId");
-        public static readonly OperationParam EntityServiceEntityType = new OperationParam("entityType");
-        public static readonly OperationParam EntityServiceEntitySubtype = new OperationParam("entitySubtype");
-        public static readonly OperationParam EntityServiceData = new OperationParam("data");
-        public static readonly OperationParam EntityServiceAcl = new OperationParam("acl");
-        public static readonly OperationParam EntityServiceFriendData = new OperationParam("friendData");
-        public static readonly OperationParam EntityServiceVersion = new OperationParam("version");
-        public static readonly OperationParam EntityServiceUpdateOps = new OperationParam("updateOps");
-        public static readonly OperationParam EntityServiceTargetPlayerId = new OperationParam("targetPlayerId");
+        public static readonly OperationParam EntityServiceEntityId = "entityId";
+        public static readonly OperationParam EntityServiceEntityType = "entityType";
+        public static readonly OperationParam EntityServiceEntitySubtype = "entitySubtype";
+        public static readonly OperationParam EntityServiceData = "data";
+        public static readonly OperationParam EntityServiceAcl = "acl";
+        public static readonly OperationParam EntityServiceFriendData = "friendData";
+        public static readonly OperationParam EntityServiceVersion = "version";
+        public static readonly OperationParam EntityServiceUpdateOps = "updateOps";
+        public static readonly OperationParam EntityServiceTargetPlayerId = "targetPlayerId";
 
         // Global Entity Service - Params
-        public static readonly OperationParam GlobalEntityServiceEntityId = new OperationParam("entityId");
-        public static readonly OperationParam GlobalEntityServiceEntityType = new OperationParam("entityType");
-        public static readonly OperationParam GlobalEntityServiceIndexedId = new OperationParam("entityIndexedId");
-        public static readonly OperationParam GlobalEntityServiceTimeToLive = new OperationParam("timeToLive");
-        public static readonly OperationParam GlobalEntityServiceData = new OperationParam("data");
-        public static readonly OperationParam GlobalEntityServiceAcl = new OperationParam("acl");
-        public static readonly OperationParam GlobalEntityServiceVersion = new OperationParam("version");
-        public static readonly OperationParam GlobalEntityServiceMaxReturn = new OperationParam("maxReturn");
-        public static readonly OperationParam GlobalEntityServiceWhere = new OperationParam("where");
-        public static readonly OperationParam GlobalEntityServiceOrderBy = new OperationParam("orderBy");
-        public static readonly OperationParam GlobalEntityServiceContext = new OperationParam("context");
-        public static readonly OperationParam GlobalEntityServicePageOffset = new OperationParam("pageOffset");
-        public static readonly OperationParam OwnerId = new OperationParam("ownerId");
+        public static readonly OperationParam GlobalEntityServiceEntityId = "entityId";
+        public static readonly OperationParam GlobalEntityServiceEntityType = "entityType";
+        public static readonly OperationParam GlobalEntityServiceIndexedId = "entityIndexedId";
+        public static readonly OperationParam GlobalEntityServiceTimeToLive = "timeToLive";
+        public static readonly OperationParam GlobalEntityServiceData = "data";
+        public static readonly OperationParam GlobalEntityServiceAcl = "acl";
+        public static readonly OperationParam GlobalEntityServiceVersion = "version";
+        public static readonly OperationParam GlobalEntityServiceMaxReturn = "maxReturn";
+        public static readonly OperationParam GlobalEntityServiceWhere = "where";
+        public static readonly OperationParam GlobalEntityServiceOrderBy = "orderBy";
+        public static readonly OperationParam GlobalEntityServiceContext = "context";
+        public static readonly OperationParam GlobalEntityServicePageOffset = "pageOffset";
+        public static readonly OperationParam OwnerId = "ownerId";
 
         // Event Service - Send Params
-        public static readonly OperationParam EventServiceSendToId = new OperationParam("toId");
-        public static readonly OperationParam EventServiceSendToIds = new OperationParam("toIds");
-        public static readonly OperationParam EventServiceSendEventType = new OperationParam("eventType");
-        public static readonly OperationParam EventServiceSendEventId = new OperationParam("eventId");
-        public static readonly OperationParam EventServiceSendEventData = new OperationParam("eventData");
-        public static readonly OperationParam EventServiceSendRecordLocally = new OperationParam("recordLocally");
+        public static readonly OperationParam EventServiceSendToId = "toId";
+        public static readonly OperationParam EventServiceSendToIds = "toIds";
+        public static readonly OperationParam EventServiceSendEventType = "eventType";
+        public static readonly OperationParam EventServiceSendEventId = "eventId";
+        public static readonly OperationParam EventServiceSendEventData = "eventData";
+        public static readonly OperationParam EventServiceSendRecordLocally = "recordLocally";
 
         // Event Service - Update Event Data Params
-        public static readonly OperationParam EventServiceUpdateEventDataFromId = new OperationParam("fromId");
-        public static readonly OperationParam EventServiceUpdateEventDataEventId = new OperationParam("eventId");
-        public static readonly OperationParam EventServiceUpdateEventDataData = new OperationParam("eventData");
-        public static readonly OperationParam EvId = new OperationParam("evId");
-        public static readonly OperationParam EventServiceEvIds  = new OperationParam("evIds");
-        public static readonly OperationParam EventServiceDateMillis  = new OperationParam("dateMillis");
-        public static readonly OperationParam EventServiceEventType   = new OperationParam("eventType");
+        public static readonly OperationParam EventServiceUpdateEventDataFromId = "fromId";
+        public static readonly OperationParam EventServiceUpdateEventDataEventId = "eventId";
+        public static readonly OperationParam EventServiceUpdateEventDataData = "eventData";
+        public static readonly OperationParam EvId = "evId";
+        public static readonly OperationParam EventServiceEvIds  = "evIds";
+        public static readonly OperationParam EventServiceDateMillis  = "dateMillis";
+        public static readonly OperationParam EventServiceEventType   = "eventType";
         
         // Event Service - Delete Incoming Params
-        public static readonly OperationParam EventServiceDeleteIncomingEventId = new OperationParam("eventId");
-        public static readonly OperationParam EventServiceDeleteIncomingFromId = new OperationParam("fromId");
+        public static readonly OperationParam EventServiceDeleteIncomingEventId = "eventId";
+        public static readonly OperationParam EventServiceDeleteIncomingFromId = "fromId";
 
         // Event Service - Delete Sent Params
-        public static readonly OperationParam EventServiceDeleteSentEventId = new OperationParam("eventId");
-        public static readonly OperationParam EventServiceDeleteSentToId = new OperationParam("toId");
-        public static readonly OperationParam EventServiceIncludeIncomingEvents = new OperationParam("includeIncomingEvents");
-        public static readonly OperationParam EventServiceIncludeSentEvents = new OperationParam("includeSentEvents");
+        public static readonly OperationParam EventServiceDeleteSentEventId = "eventId";
+        public static readonly OperationParam EventServiceDeleteSentToId = "toId";
+        public static readonly OperationParam EventServiceIncludeIncomingEvents = "includeIncomingEvents";
+        public static readonly OperationParam EventServiceIncludeSentEvents = "includeSentEvents";
 
         // Friend Service - Params
-        public static readonly OperationParam FriendServiceEntityId = new OperationParam("entityId");
-        public static readonly OperationParam FriendServiceExternalId = new OperationParam("externalId");
-        public static readonly OperationParam FriendServiceExternalIds = new OperationParam("externalIds");
-        public static readonly OperationParam FriendServiceProfileId = new OperationParam("profileId");
-        public static readonly OperationParam FriendServiceFriendId = new OperationParam("friendId");
-        public static readonly OperationParam FriendServiceAuthenticationType = new OperationParam("authenticationType");
-        public static readonly OperationParam ExternalAuthType = new OperationParam("externalAuthType");
-        public static readonly OperationParam FriendServiceEntityType = new OperationParam("entityType");
-        public static readonly OperationParam FriendServiceEntitySubtype = new OperationParam("entitySubtype");
-        public static readonly OperationParam FriendServiceIncludeSummaryData = new OperationParam("includeSummaryData");
-        public static readonly OperationParam FriendServiceFriendPlatform = new OperationParam("friendPlatform");
-        public static readonly OperationParam FriendServiceProfileIds = new OperationParam("profileIds");
-        public static readonly OperationParam FriendServiceMode = new OperationParam("mode");
+        public static readonly OperationParam FriendServiceEntityId = "entityId";
+        public static readonly OperationParam FriendServiceExternalId = "externalId";
+        public static readonly OperationParam FriendServiceExternalIds = "externalIds";
+        public static readonly OperationParam FriendServiceProfileId = "profileId";
+        public static readonly OperationParam FriendServiceFriendId = "friendId";
+        public static readonly OperationParam FriendServiceAuthenticationType = "authenticationType";
+        public static readonly OperationParam ExternalAuthType = "externalAuthType";
+        public static readonly OperationParam FriendServiceEntityType = "entityType";
+        public static readonly OperationParam FriendServiceEntitySubtype = "entitySubtype";
+        public static readonly OperationParam FriendServiceIncludeSummaryData = "includeSummaryData";
+        public static readonly OperationParam FriendServiceFriendPlatform = "friendPlatform";
+        public static readonly OperationParam FriendServiceProfileIds = "profileIds";
+        public static readonly OperationParam FriendServiceMode = "mode";
 
         // Friend Service operations
-        //public static readonly Operation FriendServiceReadFriends = new Operation("READ_FRIENDS");
+        //public static readonly Operation FriendServiceReadFriends = new Operation("READ_FRIENDS";
 
         // Friend Service - Read Player State Params
-        public static readonly OperationParam FriendServiceReadPlayerStateFriendId = new OperationParam("friendId");
-        public static readonly OperationParam FriendServiceSearchText = new OperationParam("searchText");
-        public static readonly OperationParam FriendServiceMaxResults = new OperationParam("maxResults");
+        public static readonly OperationParam FriendServiceReadPlayerStateFriendId = "friendId";
+        public static readonly OperationParam FriendServiceSearchText = "searchText";
+        public static readonly OperationParam FriendServiceMaxResults = "maxResults";
 
 
         // Friend Data Service - Read Friends Params (C++ only?)
-        //public static readonly Operation FriendDataServiceReadFriends = new Operation("");
+        //public static readonly Operation FriendDataServiceReadFriends = new Operation("";
         //friendIdList;
         //friendIdCount;
 
         //Achievements Event Data Params
-        public static readonly OperationParam GamificationServiceAchievementsName = new OperationParam("achievements");
-        public static readonly OperationParam GamificationServiceAchievementsData = new OperationParam("data");
-        public static readonly OperationParam GamificationServiceAchievementsGranted = new OperationParam("achievementsGranted");
-        public static readonly OperationParam GamificationServiceCategory = new OperationParam("category");
-        public static readonly OperationParam GamificationServiceMilestones = new OperationParam("milestones");
-        public static readonly OperationParam GamificationServiceIncludeMetaData = new OperationParam("includeMetaData");
+        public static readonly OperationParam GamificationServiceAchievementsName = "achievements";
+        public static readonly OperationParam GamificationServiceAchievementsData = "data";
+        public static readonly OperationParam GamificationServiceAchievementsGranted = "achievementsGranted";
+        public static readonly OperationParam GamificationServiceCategory = "category";
+        public static readonly OperationParam GamificationServiceMilestones = "milestones";
+        public static readonly OperationParam GamificationServiceIncludeMetaData = "includeMetaData";
 
         // Player Statistic Event Params
-        public static readonly OperationParam PlayerStatisticEventServiceEventName = new OperationParam("eventName");
-        public static readonly OperationParam PlayerStatisticEventServiceEventMultiplier = new OperationParam("eventMultiplier");
-        public static readonly OperationParam PlayerStatisticEventServiceEvents = new OperationParam("events");
+        public static readonly OperationParam PlayerStatisticEventServiceEventName = "eventName";
+        public static readonly OperationParam PlayerStatisticEventServiceEventMultiplier = "eventMultiplier";
+        public static readonly OperationParam PlayerStatisticEventServiceEvents = "events";
 
         // Presence Params
-        public static readonly OperationParam PresenceServicePlatform = new OperationParam("platform");
-        public static readonly OperationParam PresenceServiceIncludeOffline = new OperationParam("includeOffline");
-        public static readonly OperationParam PresenceServiceGroupId = new OperationParam("groupId");
-        public static readonly OperationParam PresenceServiceProfileIds = new OperationParam("profileIds");
-        public static readonly OperationParam PresenceServiceBidirectional = new OperationParam("bidirectional");
-        public static readonly OperationParam PresenceServiceVisibile = new OperationParam("visible");
-        public static readonly OperationParam PresenceServiceActivity = new OperationParam("activity");
+        public static readonly OperationParam PresenceServicePlatform = "platform";
+        public static readonly OperationParam PresenceServiceIncludeOffline = "includeOffline";
+        public static readonly OperationParam PresenceServiceGroupId = "groupId";
+        public static readonly OperationParam PresenceServiceProfileIds = "profileIds";
+        public static readonly OperationParam PresenceServiceBidirectional = "bidirectional";
+        public static readonly OperationParam PresenceServiceVisibile = "visible";
+        public static readonly OperationParam PresenceServiceActivity = "activity";
 
         // Player State Service - Read Params
-        public static readonly OperationParam PlayerStateServiceReadEntitySubtype = new OperationParam("entitySubType");
+        public static readonly OperationParam PlayerStateServiceReadEntitySubtype = "entitySubType";
 
         // Player State Service - Update Summary Params
-        public static readonly OperationParam PlayerStateServiceUpdateSummaryFriendData = new OperationParam("summaryFriendData");
-        public static readonly OperationParam PlayerStateServiceUpdateNameData = new OperationParam("playerName");
-        public static readonly OperationParam PlayerStateServiceTimeZoneOffset = new OperationParam("timeZoneOffset");
-        public static readonly OperationParam PlayerStateServiceLanguageCode = new OperationParam("languageCode");
+        public static readonly OperationParam PlayerStateServiceUpdateSummaryFriendData = "summaryFriendData";
+        public static readonly OperationParam PlayerStateServiceUpdateNameData = "playerName";
+        public static readonly OperationParam PlayerStateServiceTimeZoneOffset = "timeZoneOffset";
+        public static readonly OperationParam PlayerStateServiceLanguageCode = "languageCode";
 
         // Player State Service - Atributes
-        public static readonly OperationParam PlayerStateServiceAttributes = new OperationParam("attributes");
-        public static readonly OperationParam PlayerStateServiceWipeExisting = new OperationParam("wipeExisting");
+        public static readonly OperationParam PlayerStateServiceAttributes = "attributes";
+        public static readonly OperationParam PlayerStateServiceWipeExisting = "wipeExisting";
 
-        public static readonly OperationParam PlayerStateServiceIncludeSummaryData = new OperationParam("includePlayerSummaryData");
+        public static readonly OperationParam PlayerStateServiceIncludeSummaryData = "includePlayerSummaryData";
 
         // Player State Service - UPDATE_PICTURE_URL
-        public static readonly OperationParam PlayerStateServicePlayerPictureUrl = new OperationParam("playerPictureUrl");
-        public static readonly OperationParam PlayerStateServiceContactEmail = new OperationParam("contactEmail");
+        public static readonly OperationParam PlayerStateServicePlayerPictureUrl = "playerPictureUrl";
+        public static readonly OperationParam PlayerStateServiceContactEmail = "contactEmail";
 
         // Player State Service - Reset Params
-        //public static readonly Operation PlayerStateServiceReset = new Operation("");
+        //public static readonly Operation PlayerStateServiceReset = new Operation("";
         
 
         // Player Statistics Service - Update Increment Params
-        public static readonly OperationParam PlayerStatisticsServiceStats = new OperationParam("statistics");
-        public static readonly OperationParam PlayerStatisticsServiceStatNames = new OperationParam("statNames");
-        public static readonly OperationParam PlayerStatisticsExperiencePoints = new OperationParam("xp_points");
+        public static readonly OperationParam PlayerStatisticsServiceStats = "statistics";
+        public static readonly OperationParam PlayerStatisticsServiceStatNames = "statNames";
+        public static readonly OperationParam PlayerStatisticsExperiencePoints = "xp_points";
 
         // Player Statistics Service - Status Param
-        public static readonly OperationParam PlayerStateServiceStatusName = new OperationParam("statusName");
+        public static readonly OperationParam PlayerStateServiceStatusName = "statusName";
         
         // Player Statistics Service - Extend User Status Params
-        public static readonly OperationParam PlayerStateServiceAdditionalSecs = new OperationParam("additionalSecs");
-        public static readonly OperationParam PlayerStateServiceDetails = new OperationParam("details");
+        public static readonly OperationParam PlayerStateServiceAdditionalSecs = "additionalSecs";
+        public static readonly OperationParam PlayerStateServiceDetails = "details";
 
-        public static readonly OperationParam PlayerStateServiceDurationSecs = new OperationParam("durationSecs");
+        public static readonly OperationParam PlayerStateServiceDurationSecs = "durationSecs";
 
         // Player Statistics Service - Read Params
-        public static readonly OperationParam PlayerStatisticsServiceReadEntitySubType = new OperationParam("entitySubType");
+        public static readonly OperationParam PlayerStatisticsServiceReadEntitySubType = "entitySubType";
 
-        //public static readonly Operation PlayerStatisticsServiceDelete = new Operation("DELETE");
+        //public static readonly Operation PlayerStatisticsServiceDelete = new Operation("DELETE";
 
         // Push Notification Service operations (C++ only??)
-        //public static readonly Operation PushNotificationServiceCreate = new Operation("CREATE");
-        //public static readonly Operation PushNotificationServiceRegister = new Operation("REGISTER");
+        //public static readonly Operation PushNotificationServiceCreate = new Operation("CREATE";
+        //public static readonly Operation PushNotificationServiceRegister = new Operation("REGISTER";
 
         // Social Leaderboard Service - general parameters
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardId = new OperationParam("leaderboardId");
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardIds = new OperationParam("leaderboardIds");
-        public static readonly OperationParam SocialLeaderboardServiceReplaceName = new OperationParam("replaceName");
-        public static readonly OperationParam SocialLeaderboardServiceScore = new OperationParam("score");
-        public static readonly OperationParam SocialLeaderboardServiceScoreData = new OperationParam("scoreData");
-        public static readonly OperationParam SocialLeaderboardServiceConfigJson = new OperationParam("configJson");
-        public static readonly OperationParam SocialLeaderboardServiceData = new OperationParam("data");
-        public static readonly OperationParam SocialLeaderboardServiceEventName = new OperationParam("eventName");
-        public static readonly OperationParam SocialLeaderboardServiceEventMultiplier = new OperationParam("eventMultiplier");
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardType = new OperationParam("leaderboardType");
-        public static readonly OperationParam SocialLeaderboardServiceRotationType = new OperationParam("rotationType");
-        public static readonly OperationParam SocialLeaderboardServiceRotationReset = new OperationParam("rotationReset");
-        public static readonly OperationParam SocialLeaderboardServiceRetainedCount = new OperationParam("retainedCount");
-        public static readonly OperationParam NumDaysToRotate = new OperationParam("numDaysToRotate");
-        public static readonly OperationParam SocialLeaderboardServiceFetchType = new OperationParam("fetchType");
-        public static readonly OperationParam SocialLeaderboardServiceMaxResults = new OperationParam("maxResults");
-        public static readonly OperationParam SocialLeaderboardServiceSort = new OperationParam("sort");
-        public static readonly OperationParam SocialLeaderboardServiceStartIndex = new OperationParam("startIndex");
-        public static readonly OperationParam SocialLeaderboardServiceEndIndex = new OperationParam("endIndex");
-        public static readonly OperationParam SocialLeaderboardServiceBeforeCount = new OperationParam("beforeCount");
-        public static readonly OperationParam SocialLeaderboardServiceAfterCount = new OperationParam("afterCount");
-        public static readonly OperationParam SocialLeaderboardServiceIncludeLeaderboardSize = new OperationParam("includeLeaderboardSize");
-        public static readonly OperationParam SocialLeaderboardServiceVersionId = new OperationParam("versionId");
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardResultCount = new OperationParam("leaderboardResultCount");
-        public static readonly OperationParam SocialLeaderboardServiceGroupId = new OperationParam("groupId");
-        public static readonly OperationParam SocialLeaderboardServiceProfileIds = new OperationParam("profileIds");
-        public static readonly OperationParam SocialLeaderboardServiceRotationResetTime = new OperationParam("rotationResetTime");
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardId = "leaderboardId";
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardIds = "leaderboardIds";
+        public static readonly OperationParam SocialLeaderboardServiceReplaceName = "replaceName";
+        public static readonly OperationParam SocialLeaderboardServiceScore = "score";
+        public static readonly OperationParam SocialLeaderboardServiceScoreData = "scoreData";
+        public static readonly OperationParam SocialLeaderboardServiceConfigJson = "configJson";
+        public static readonly OperationParam SocialLeaderboardServiceData = "data";
+        public static readonly OperationParam SocialLeaderboardServiceEventName = "eventName";
+        public static readonly OperationParam SocialLeaderboardServiceEventMultiplier = "eventMultiplier";
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardType = "leaderboardType";
+        public static readonly OperationParam SocialLeaderboardServiceRotationType = "rotationType";
+        public static readonly OperationParam SocialLeaderboardServiceRotationReset = "rotationReset";
+        public static readonly OperationParam SocialLeaderboardServiceRetainedCount = "retainedCount";
+        public static readonly OperationParam NumDaysToRotate = "numDaysToRotate";
+        public static readonly OperationParam SocialLeaderboardServiceFetchType = "fetchType";
+        public static readonly OperationParam SocialLeaderboardServiceMaxResults = "maxResults";
+        public static readonly OperationParam SocialLeaderboardServiceSort = "sort";
+        public static readonly OperationParam SocialLeaderboardServiceStartIndex = "startIndex";
+        public static readonly OperationParam SocialLeaderboardServiceEndIndex = "endIndex";
+        public static readonly OperationParam SocialLeaderboardServiceBeforeCount = "beforeCount";
+        public static readonly OperationParam SocialLeaderboardServiceAfterCount = "afterCount";
+        public static readonly OperationParam SocialLeaderboardServiceIncludeLeaderboardSize = "includeLeaderboardSize";
+        public static readonly OperationParam SocialLeaderboardServiceVersionId = "versionId";
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardResultCount = "leaderboardResultCount";
+        public static readonly OperationParam SocialLeaderboardServiceGroupId = "groupId";
+        public static readonly OperationParam SocialLeaderboardServiceProfileIds = "profileIds";
+        public static readonly OperationParam SocialLeaderboardServiceRotationResetTime = "rotationResetTime";
 
 
         // Social Leaderboard Service - Reset Score Params
-        //public static readonly Operation SocialLeaderboardServiceResetScore = new Operation("");
+        //public static readonly Operation SocialLeaderboardServiceResetScore = new Operation("";
 
         // Product Service
-        public static readonly OperationParam ProductServiceCurrencyId = new OperationParam("vc_id");
-        public static readonly OperationParam ProductServiceCurrencyAmount = new OperationParam("vc_amount");
+        public static readonly OperationParam ProductServiceCurrencyId = "vc_id";
+        public static readonly OperationParam ProductServiceCurrencyAmount = "vc_amount";
 
         // AppStore 
-        public static readonly OperationParam AppStoreServiceStoreId = new OperationParam("storeId");
-        public static readonly OperationParam AppStoreServiceIAPId = new OperationParam("iapId");
-        public static readonly OperationParam AppStoreServiceReceiptData = new OperationParam("receiptData");
-        public static readonly OperationParam AppStoreServicePurchaseData = new OperationParam("purchaseData");
-        public static readonly OperationParam AppStoreServiceTransactionId = new OperationParam("transactionId");
-        public static readonly OperationParam AppStoreServiceTransactionData = new OperationParam("transactionData");
-        public static readonly OperationParam AppStoreServicePriceInfoCriteria = new OperationParam("priceInfoCriteria");
-        public static readonly OperationParam AppStoreServiceUserCurrency = new OperationParam("userCurrency");
-        public static readonly OperationParam AppStoreServiceCategory = new OperationParam("category");
-        public static readonly OperationParam AppStoreServicePayload = new OperationParam("payload");
+        public static readonly OperationParam AppStoreServiceStoreId = "storeId";
+        public static readonly OperationParam AppStoreServiceIAPId = "iapId";
+        public static readonly OperationParam AppStoreServiceReceiptData = "receiptData";
+        public static readonly OperationParam AppStoreServicePurchaseData = "purchaseData";
+        public static readonly OperationParam AppStoreServiceTransactionId = "transactionId";
+        public static readonly OperationParam AppStoreServiceTransactionData = "transactionData";
+        public static readonly OperationParam AppStoreServicePriceInfoCriteria = "priceInfoCriteria";
+        public static readonly OperationParam AppStoreServiceUserCurrency = "userCurrency";
+        public static readonly OperationParam AppStoreServiceCategory = "category";
+        public static readonly OperationParam AppStoreServicePayload = "payload";
 
         // Virtual Currency Service
-        public static readonly OperationParam VirtualCurrencyServiceCurrencyId = new OperationParam("vcId");
-        public static readonly OperationParam VirtualCurrencyServiceCurrencyAmount = new OperationParam("vcAmount");
+        public static readonly OperationParam VirtualCurrencyServiceCurrencyId = "vcId";
+        public static readonly OperationParam VirtualCurrencyServiceCurrencyAmount = "vcAmount";
 
         // Product Service - Get Inventory Params
-        public static readonly OperationParam ProductServiceGetInventoryPlatform = new OperationParam("platform");
-        public static readonly OperationParam ProductServiceGetInventoryUserCurrency = new OperationParam("user_currency");
-        public static readonly OperationParam ProductServiceGetInventoryCategory = new OperationParam("category");
+        public static readonly OperationParam ProductServiceGetInventoryPlatform = "platform";
+        public static readonly OperationParam ProductServiceGetInventoryUserCurrency = "user_currency";
+        public static readonly OperationParam ProductServiceGetInventoryCategory = "category";
 
         // Product Service - Op Cash In Receipt Params
-        public static readonly OperationParam ProductServiceOpCashInReceiptReceipt = new OperationParam("receipt"); //C++ only
-        public static readonly OperationParam ProductServiceOpCashInReceiptUrl = new OperationParam("url"); //C++ only
+        public static readonly OperationParam ProductServiceOpCashInReceiptReceipt = "receipt"; //C++ only
+        public static readonly OperationParam ProductServiceOpCashInReceiptUrl = "url"; //C++ only
 
         // Product Service - Reset Player VC Params
-        //public static readonly OperationParam ProductServiceResetPlayerVC = new OperationParam("");
+        //public static readonly OperationParam ProductServiceResetPlayerVC = "";
 
         // Heartbeat Service - Params
-        //public static readonly OperationParam HeartbeatService = new OperationParam("");
+        //public static readonly OperationParam HeartbeatService = "";
 
         // Time Service - Params
-        //public static readonly OperationParam TimeService = new OperationParam("");
+        //public static readonly OperationParam TimeService = "";
 
         // Server Time Service - Read Params
-        public static readonly OperationParam ServerTimeServiceRead = new OperationParam("");
+        public static readonly OperationParam ServerTimeServiceRead = "";
 
         // data creation parms
-        public static readonly OperationParam ServiceMessageService = new OperationParam("service");
-        public static readonly OperationParam ServiceMessageOperation = new OperationParam("operation");
-        public static readonly OperationParam ServiceMessageData = new OperationParam("data");
+        public static readonly OperationParam ServiceMessageService = "service";
+        public static readonly OperationParam ServiceMessageOperation = "operation";
+        public static readonly OperationParam ServiceMessageData = "data";
 
         // data bundle creation parms
-        public static readonly OperationParam ServiceMessagePacketId = new OperationParam("packetId");
-        public static readonly OperationParam ServiceMessageSessionId = new OperationParam("sessionId");
-        public static readonly OperationParam ServiceMessageGameId = new OperationParam("gameId");
-        public static readonly OperationParam ServiceMessageMessages = new OperationParam("messages");
-        public static readonly OperationParam ProfileId = new OperationParam("profileId");
+        public static readonly OperationParam ServiceMessagePacketId = "packetId";
+        public static readonly OperationParam ServiceMessageSessionId = "sessionId";
+        public static readonly OperationParam ServiceMessageGameId = "gameId";
+        public static readonly OperationParam ServiceMessageMessages = "messages";
+        public static readonly OperationParam ProfileId = "profileId";
 
         // Error Params
-        public static readonly OperationParam ServiceMessageReasonCode = new OperationParam("reason_code");
-        public static readonly OperationParam ServiceMessageStatusMessage = new OperationParam("status_message");
+        public static readonly OperationParam ServiceMessageReasonCode = "reason_code";
+        public static readonly OperationParam ServiceMessageStatusMessage = "status_message";
 
-        public static readonly OperationParam DeviceRegistrationTypeIos = new OperationParam("IOS");
-        public static readonly OperationParam DeviceRegistrationTypeAndroid = new OperationParam("ANG");
+        public static readonly OperationParam DeviceRegistrationTypeIos = "IOS";
+        public static readonly OperationParam DeviceRegistrationTypeAndroid = "ANG";
 
-        public static readonly OperationParam ScriptServiceRunScriptName = new OperationParam("scriptName");
-        public static readonly OperationParam ScriptServiceRunScriptData = new OperationParam("scriptData");
-        public static readonly OperationParam ScriptServiceStartDateUTC = new OperationParam("startDateUTC");
-        public static readonly OperationParam ScriptServiceStartMinutesFromNow = new OperationParam("minutesFromNow");
-        public static readonly OperationParam ScriptServiceParentLevel = new OperationParam("parentLevel");
-        public static readonly OperationParam ScriptServiceJobId = new OperationParam("jobId");
+        public static readonly OperationParam ScriptServiceRunScriptName = "scriptName";
+        public static readonly OperationParam ScriptServiceRunScriptData = "scriptData";
+        public static readonly OperationParam ScriptServiceStartDateUTC = "startDateUTC";
+        public static readonly OperationParam ScriptServiceStartMinutesFromNow = "minutesFromNow";
+        public static readonly OperationParam ScriptServiceParentLevel = "parentLevel";
+        public static readonly OperationParam ScriptServiceJobId = "jobId";
 
-        public static readonly OperationParam MatchMakingServicePlayerRating = new OperationParam("playerRating");
-        public static readonly OperationParam MatchMakingServiceMinutes = new OperationParam("minutes");
-        public static readonly OperationParam MatchMakingServiceRangeDelta = new OperationParam("rangeDelta");
-        public static readonly OperationParam MatchMakingServiceNumMatches = new OperationParam("numMatches");
-        public static readonly OperationParam MatchMakingServiceAttributes = new OperationParam("attributes");
-        public static readonly OperationParam MatchMakingServiceExtraParams = new OperationParam("extraParms");
-        public static readonly OperationParam MatchMakingServicePlayerId = new OperationParam("playerId");
-        public static readonly OperationParam MatchMakingServicePlaybackStreamId = new OperationParam("playbackStreamId");
+        public static readonly OperationParam MatchMakingServicePlayerRating = "playerRating";
+        public static readonly OperationParam MatchMakingServiceMinutes = "minutes";
+        public static readonly OperationParam MatchMakingServiceRangeDelta = "rangeDelta";
+        public static readonly OperationParam MatchMakingServiceNumMatches = "numMatches";
+        public static readonly OperationParam MatchMakingServiceAttributes = "attributes";
+        public static readonly OperationParam MatchMakingServiceExtraParams = "extraParms";
+        public static readonly OperationParam MatchMakingServicePlayerId = "playerId";
+        public static readonly OperationParam MatchMakingServicePlaybackStreamId = "playbackStreamId";
 
-        public static readonly OperationParam OfflineMatchServicePlayerId = new OperationParam("playerId");
-        public static readonly OperationParam OfflineMatchServiceRangeDelta = new OperationParam("rangeDelta");
-        public static readonly OperationParam OfflineMatchServicePlaybackStreamId = new OperationParam("playbackStreamId");
+        public static readonly OperationParam OfflineMatchServicePlayerId = "playerId";
+        public static readonly OperationParam OfflineMatchServiceRangeDelta = "rangeDelta";
+        public static readonly OperationParam OfflineMatchServicePlaybackStreamId = "playbackStreamId";
 
-        public static readonly OperationParam PlaybackStreamServiceTargetPlayerId = new OperationParam("targetPlayerId");
-        public static readonly OperationParam PlaybackStreamServiceInitiatingPlayerId = new OperationParam("initiatingPlayerId");
-        public static readonly OperationParam PlaybackStreamServiceMaxNumberOfStreams = new OperationParam("maxNumStreams");
-        public static readonly OperationParam PlaybackStreamServiceIncludeSharedData = new OperationParam("includeSharedData");
-        public static readonly OperationParam PlaybackStreamServicePlaybackStreamId = new OperationParam("playbackStreamId");
-        public static readonly OperationParam PlaybackStreamServiceEventData = new OperationParam("eventData");
-        public static readonly OperationParam PlaybackStreamServiceSummary = new OperationParam("summary");
-        public static readonly OperationParam PlaybackStreamServiceNumDays = new OperationParam("numDays");
+        public static readonly OperationParam PlaybackStreamServiceTargetPlayerId = "targetPlayerId";
+        public static readonly OperationParam PlaybackStreamServiceInitiatingPlayerId = "initiatingPlayerId";
+        public static readonly OperationParam PlaybackStreamServiceMaxNumberOfStreams = "maxNumStreams";
+        public static readonly OperationParam PlaybackStreamServiceIncludeSharedData = "includeSharedData";
+        public static readonly OperationParam PlaybackStreamServicePlaybackStreamId = "playbackStreamId";
+        public static readonly OperationParam PlaybackStreamServiceEventData = "eventData";
+        public static readonly OperationParam PlaybackStreamServiceSummary = "summary";
+        public static readonly OperationParam PlaybackStreamServiceNumDays = "numDays";
 
-        public static readonly OperationParam ProductServiceTransId = new OperationParam("transId");
-        public static readonly OperationParam ProductServiceOrderId = new OperationParam("orderId");
-        public static readonly OperationParam ProductServiceProductId = new OperationParam("productId");
-        public static readonly OperationParam ProductServiceLanguage = new OperationParam("language");
-        public static readonly OperationParam ProductServiceItemId = new OperationParam("itemId");
-        public static readonly OperationParam ProductServiceReceipt = new OperationParam("receipt");
-        public static readonly OperationParam ProductServiceSignedRequest = new OperationParam("signed_request");
-        public static readonly OperationParam ProductServiceToken = new OperationParam("token");
+        public static readonly OperationParam ProductServiceTransId = "transId";
+        public static readonly OperationParam ProductServiceOrderId = "orderId";
+        public static readonly OperationParam ProductServiceProductId = "productId";
+        public static readonly OperationParam ProductServiceLanguage = "language";
+        public static readonly OperationParam ProductServiceItemId = "itemId";
+        public static readonly OperationParam ProductServiceReceipt = "receipt";
+        public static readonly OperationParam ProductServiceSignedRequest = "signed_request";
+        public static readonly OperationParam ProductServiceToken = "token";
 
         //S3 Service
-        public static readonly OperationParam S3HandlingServiceFileCategory = new OperationParam("category");
-        public static readonly OperationParam S3HandlingServiceFileDetails = new OperationParam("fileDetails");
-        public static readonly OperationParam S3HandlingServiceFileId = new OperationParam("fileId");
+        public static readonly OperationParam S3HandlingServiceFileCategory = "category";
+        public static readonly OperationParam S3HandlingServiceFileDetails = "fileDetails";
+        public static readonly OperationParam S3HandlingServiceFileId = "fileId";
 
         //Shared Identity
-        public static readonly OperationParam IdentityServiceForceSingleton = new OperationParam("forceSingleton");
+        public static readonly OperationParam IdentityServiceForceSingleton = "forceSingleton";
 
         //RedemptionCode
-        public static readonly OperationParam RedemptionCodeServiceScanCode = new OperationParam("scanCode");
-        public static readonly OperationParam RedemptionCodeServiceCodeType = new OperationParam("codeType");
-        public static readonly OperationParam RedemptionCodeServiceCustomRedemptionInfo = new OperationParam("customRedemptionInfo");
+        public static readonly OperationParam RedemptionCodeServiceScanCode = "scanCode";
+        public static readonly OperationParam RedemptionCodeServiceCodeType = "codeType";
+        public static readonly OperationParam RedemptionCodeServiceCustomRedemptionInfo = "customRedemptionInfo";
 
         //DataStream
-        public static readonly OperationParam DataStreamEventName = new OperationParam("eventName");
-        public static readonly OperationParam DataStreamEventProperties = new OperationParam("eventProperties");
-        public static readonly OperationParam DataStreamCrashType = new OperationParam("crashType");
-        public static readonly OperationParam DataStreamErrorMsg = new OperationParam("errorMsg");
-        public static readonly OperationParam DataStreamCrashInfo = new OperationParam("crashJson");
-        public static readonly OperationParam DataStreamCrashLog = new OperationParam("crashLog");
-        public static readonly OperationParam DataStreamUserName = new OperationParam("userName");
-        public static readonly OperationParam DataStreamUserEmail = new OperationParam("userEmail");
-        public static readonly OperationParam DataStreamUserNotes = new OperationParam("userNotes");
-        public static readonly OperationParam DataStreamUserSubmitted = new OperationParam("userSubmitted");
+        public static readonly OperationParam DataStreamEventName = "eventName";
+        public static readonly OperationParam DataStreamEventProperties = "eventProperties";
+        public static readonly OperationParam DataStreamCrashType = "crashType";
+        public static readonly OperationParam DataStreamErrorMsg = "errorMsg";
+        public static readonly OperationParam DataStreamCrashInfo = "crashJson";
+        public static readonly OperationParam DataStreamCrashLog = "crashLog";
+        public static readonly OperationParam DataStreamUserName = "userName";
+        public static readonly OperationParam DataStreamUserEmail = "userEmail";
+        public static readonly OperationParam DataStreamUserNotes = "userNotes";
+        public static readonly OperationParam DataStreamUserSubmitted = "userSubmitted";
 
         // Profanity
-        public static readonly OperationParam ProfanityText = new OperationParam("text");
-        public static readonly OperationParam ProfanityReplaceSymbol = new OperationParam("replaceSymbol");
-        public static readonly OperationParam ProfanityFlagEmail = new OperationParam("flagEmail");
-        public static readonly OperationParam ProfanityFlagPhone = new OperationParam("flagPhone");
-        public static readonly OperationParam ProfanityFlagUrls = new OperationParam("flagUrls");
-        public static readonly OperationParam ProfanityLanguages = new OperationParam("languages");
+        public static readonly OperationParam ProfanityText = "text";
+        public static readonly OperationParam ProfanityReplaceSymbol = "replaceSymbol";
+        public static readonly OperationParam ProfanityFlagEmail = "flagEmail";
+        public static readonly OperationParam ProfanityFlagPhone = "flagPhone";
+        public static readonly OperationParam ProfanityFlagUrls = "flagUrls";
+        public static readonly OperationParam ProfanityLanguages = "languages";
 
         //File upload
-        public static readonly OperationParam UploadLocalPath = new OperationParam("localPath");
-        public static readonly OperationParam UploadCloudPath = new OperationParam("cloudPath");
-        public static readonly OperationParam UploadCloudFilename = new OperationParam("cloudFilename");
-        public static readonly OperationParam UploadShareable = new OperationParam("shareable");
-        public static readonly OperationParam UploadReplaceIfExists = new OperationParam("replaceIfExists");
-        public static readonly OperationParam UploadFileSize = new OperationParam("fileSize");
-        public static readonly OperationParam UploadRecurse = new OperationParam("recurse");
-        public static readonly OperationParam UploadPath = new OperationParam("path");
+        public static readonly OperationParam UploadLocalPath = "localPath";
+        public static readonly OperationParam UploadCloudPath = "cloudPath";
+        public static readonly OperationParam UploadCloudFilename = "cloudFilename";
+        public static readonly OperationParam UploadShareable = "shareable";
+        public static readonly OperationParam UploadReplaceIfExists = "replaceIfExists";
+        public static readonly OperationParam UploadFileSize = "fileSize";
+        public static readonly OperationParam UploadRecurse = "recurse";
+        public static readonly OperationParam UploadPath = "path";
 
         //group
-        public static readonly OperationParam GroupId = new OperationParam("groupId");
-        public static readonly OperationParam GroupProfileId = new OperationParam("profileId");
-        public static readonly OperationParam GroupRole = new OperationParam("role");
-        public static readonly OperationParam GroupAttributes = new OperationParam("attributes");
-        public static readonly OperationParam GroupName = new OperationParam("name");
-        public static readonly OperationParam GroupType = new OperationParam("groupType");
-        public static readonly OperationParam GroupTypes = new OperationParam("groupTypes");
-        public static readonly OperationParam GroupEntityType = new OperationParam("entityType");
-        public static readonly OperationParam GroupIsOpenGroup = new OperationParam("isOpenGroup");
-        public static readonly OperationParam GroupAcl = new OperationParam("acl");
-        public static readonly OperationParam GroupData = new OperationParam("data");
-        public static readonly OperationParam GroupOwnerAttributes = new OperationParam("ownerAttributes");
-        public static readonly OperationParam GroupDefaultMemberAttributes = new OperationParam("defaultMemberAttributes");
-        public static readonly OperationParam GroupIsOwnedByGroupMember = new OperationParam("isOwnedByGroupMember");
-        public static readonly OperationParam GroupSummaryData = new OperationParam("summaryData");
-        public static readonly OperationParam GroupEntityId = new OperationParam("entityId");
-        public static readonly OperationParam GroupVersion = new OperationParam("version");
-        public static readonly OperationParam GroupContext = new OperationParam("context");
-        public static readonly OperationParam GroupPageOffset = new OperationParam("pageOffset");
-        public static readonly OperationParam GroupAutoJoinStrategy = new OperationParam("autoJoinStrategy");
-        public static readonly OperationParam GroupWhere = new OperationParam("where");
-        public static readonly OperationParam GroupMaxReturn = new OperationParam("maxReturn");
+        public static readonly OperationParam GroupId = "groupId";
+        public static readonly OperationParam GroupProfileId = "profileId";
+        public static readonly OperationParam GroupRole = "role";
+        public static readonly OperationParam GroupAttributes = "attributes";
+        public static readonly OperationParam GroupName = "name";
+        public static readonly OperationParam GroupType = "groupType";
+        public static readonly OperationParam GroupTypes = "groupTypes";
+        public static readonly OperationParam GroupEntityType = "entityType";
+        public static readonly OperationParam GroupIsOpenGroup = "isOpenGroup";
+        public static readonly OperationParam GroupAcl = "acl";
+        public static readonly OperationParam GroupData = "data";
+        public static readonly OperationParam GroupOwnerAttributes = "ownerAttributes";
+        public static readonly OperationParam GroupDefaultMemberAttributes = "defaultMemberAttributes";
+        public static readonly OperationParam GroupIsOwnedByGroupMember = "isOwnedByGroupMember";
+        public static readonly OperationParam GroupSummaryData = "summaryData";
+        public static readonly OperationParam GroupEntityId = "entityId";
+        public static readonly OperationParam GroupVersion = "version";
+        public static readonly OperationParam GroupContext = "context";
+        public static readonly OperationParam GroupPageOffset = "pageOffset";
+        public static readonly OperationParam GroupAutoJoinStrategy = "autoJoinStrategy";
+        public static readonly OperationParam GroupWhere = "where";
+        public static readonly OperationParam GroupMaxReturn = "maxReturn";
         
         //group file
-        public static readonly OperationParam FolderPath = new OperationParam("folderPath");
-        public static readonly OperationParam FileName = new OperationParam("filename");
-        public static readonly OperationParam FullPathFilename = new OperationParam("fullPathFilename");
-        public static readonly OperationParam FileId = new OperationParam("fileId");
-        public static readonly OperationParam Version = new OperationParam("version");
-        public static readonly OperationParam NewTreeId = new OperationParam("newTreeId");
-        public static readonly OperationParam TreeVersion = new OperationParam("treeVersion");
-        public static readonly OperationParam NewFilename = new OperationParam("newFilename");
-        public static readonly OperationParam OverwriteIfPresent = new OperationParam("overwriteIfPresent");
-        public static readonly OperationParam Recurse = new OperationParam("recurse");
-        public static readonly OperationParam UserCloudPath = new OperationParam("userCloudPath");
-        public static readonly OperationParam UserCloudFilename = new OperationParam("userCloudFilename");
-        public static readonly OperationParam GroupTreeId = new OperationParam("groupTreeId");
-        public static readonly OperationParam GroupFilename = new OperationParam("groupFilename");
-        public static readonly OperationParam GroupFileACL = new OperationParam("groupFileAcl");
-        public static readonly OperationParam NewACL = new OperationParam("newAcl");
+        public static readonly OperationParam FolderPath = "folderPath";
+        public static readonly OperationParam FileName = "filename";
+        public static readonly OperationParam FullPathFilename = "fullPathFilename";
+        public static readonly OperationParam FileId = "fileId";
+        public static readonly OperationParam Version = "version";
+        public static readonly OperationParam NewTreeId = "newTreeId";
+        public static readonly OperationParam TreeVersion = "treeVersion";
+        public static readonly OperationParam NewFilename = "newFilename";
+        public static readonly OperationParam OverwriteIfPresent = "overwriteIfPresent";
+        public static readonly OperationParam Recurse = "recurse";
+        public static readonly OperationParam UserCloudPath = "userCloudPath";
+        public static readonly OperationParam UserCloudFilename = "userCloudFilename";
+        public static readonly OperationParam GroupTreeId = "groupTreeId";
+        public static readonly OperationParam GroupFilename = "groupFilename";
+        public static readonly OperationParam GroupFileACL = "groupFileAcl";
+        public static readonly OperationParam NewACL = "newAcl";
 
 
         //GlobalFile
-        public static readonly OperationParam GlobalFileServiceFileId = new OperationParam("fileId");
-        public static readonly OperationParam GlobalFileServiceFolderPath = new OperationParam("folderPath");
-        public static readonly OperationParam GlobalFileServiceFileName = new OperationParam("filename");
-        public static readonly OperationParam GlobalFileServiceRecurse = new OperationParam("recurse");
+        public static readonly OperationParam GlobalFileServiceFileId = "fileId";
+        public static readonly OperationParam GlobalFileServiceFolderPath = "folderPath";
+        public static readonly OperationParam GlobalFileServiceFileName = "filename";
+        public static readonly OperationParam GlobalFileServiceRecurse = "recurse";
 
         //mail
-        public static readonly OperationParam Subject = new OperationParam("subject");
-        public static readonly OperationParam Body = new OperationParam("body");
-        public static readonly OperationParam ServiceParams = new OperationParam("serviceParams");
-        public static readonly OperationParam EmailAddress = new OperationParam("emailAddress");
-        public static readonly OperationParam EmailAddresses = new OperationParam("emailAddresses");
+        public static readonly OperationParam Subject = "subject";
+        public static readonly OperationParam Body = "body";
+        public static readonly OperationParam ServiceParams = "serviceParams";
+        public static readonly OperationParam EmailAddress = "emailAddress";
+        public static readonly OperationParam EmailAddresses = "emailAddresses";
 
-        public static readonly OperationParam LeaderboardId = new OperationParam("leaderboardId");
-        public static readonly OperationParam DivSetId = new OperationParam("divSetId");
-        public static readonly OperationParam VersionId = new OperationParam("versionId");
-        public static readonly OperationParam TournamentCode = new OperationParam("tournamentCode");
-        public static readonly OperationParam InitialScore = new OperationParam("initialScore");
-        public static readonly OperationParam Score = new OperationParam("score");
-        public static readonly OperationParam RoundStartedEpoch = new OperationParam("roundStartedEpoch");
-        public static readonly OperationParam Data = new OperationParam("data");
+        public static readonly OperationParam LeaderboardId = "leaderboardId";
+        public static readonly OperationParam DivSetId = "divSetId";
+        public static readonly OperationParam VersionId = "versionId";
+        public static readonly OperationParam TournamentCode = "tournamentCode";
+        public static readonly OperationParam InitialScore = "initialScore";
+        public static readonly OperationParam Score = "score";
+        public static readonly OperationParam RoundStartedEpoch = "roundStartedEpoch";
+        public static readonly OperationParam Data = "data";
 
         // chat
-        public static readonly OperationParam ChatChannelId = new OperationParam("channelId");
-        public static readonly OperationParam ChatMaxReturn = new OperationParam("maxReturn");
-        public static readonly OperationParam ChatMessageId = new OperationParam("msgId");
-        public static readonly OperationParam ChatVersion = new OperationParam("version");
+        public static readonly OperationParam ChatChannelId = "channelId";
+        public static readonly OperationParam ChatMaxReturn = "maxReturn";
+        public static readonly OperationParam ChatMessageId = "msgId";
+        public static readonly OperationParam ChatVersion = "version";
         
-        public static readonly OperationParam ChatChannelType = new OperationParam("channelType");
-        public static readonly OperationParam ChatChannelSubId = new OperationParam("channelSubId");
-        public static readonly OperationParam ChatContent = new OperationParam("content");
-        public static readonly OperationParam ChatText = new OperationParam("text");
+        public static readonly OperationParam ChatChannelType = "channelType";
+        public static readonly OperationParam ChatChannelSubId = "channelSubId";
+        public static readonly OperationParam ChatContent = "content";
+        public static readonly OperationParam ChatText = "text";
 
-        public static readonly OperationParam ChatRich = new OperationParam("rich");
-        public static readonly OperationParam ChatRecordInHistory = new OperationParam("recordInHistory");
+        public static readonly OperationParam ChatRich = "rich";
+        public static readonly OperationParam ChatRecordInHistory = "recordInHistory";
 
         // TODO:: do we enumerate these ? [smrj]
         // chat channel types 
-        public static readonly OperationParam AllChannelType = new OperationParam("all");
-        public static readonly OperationParam GlobalChannelType = new OperationParam("gl");
-        public static readonly OperationParam GroupChannelType = new OperationParam("gr");
+        public static readonly OperationParam AllChannelType = "all";
+        public static readonly OperationParam GlobalChannelType = "gl";
+        public static readonly OperationParam GroupChannelType = "gr";
 
         // messaging
-        public static readonly OperationParam MessagingMessageBox = new OperationParam("msgbox");
-        public static readonly OperationParam MessagingMessageIds = new OperationParam("msgIds");
-        public static readonly OperationParam MessagingMarkAsRead = new OperationParam("markAsRead");
-        public static readonly OperationParam MessagingContext = new OperationParam("context");
-        public static readonly OperationParam MessagingPageOffset = new OperationParam("pageOffset");
-        public static readonly OperationParam MessagingFromName = new OperationParam("fromName");
-        public static readonly OperationParam MessagingToProfileIds = new OperationParam("toProfileIds");
-        public static readonly OperationParam MessagingContent = new OperationParam("contentJson");
-        public static readonly OperationParam MessagingSubject = new OperationParam("subject");
-        public static readonly OperationParam MessagingText = new OperationParam("text");
+        public static readonly OperationParam MessagingMessageBox = "msgbox";
+        public static readonly OperationParam MessagingMessageIds = "msgIds";
+        public static readonly OperationParam MessagingMarkAsRead = "markAsRead";
+        public static readonly OperationParam MessagingContext = "context";
+        public static readonly OperationParam MessagingPageOffset = "pageOffset";
+        public static readonly OperationParam MessagingFromName = "fromName";
+        public static readonly OperationParam MessagingToProfileIds = "toProfileIds";
+        public static readonly OperationParam MessagingContent = "contentJson";
+        public static readonly OperationParam MessagingSubject = "subject";
+        public static readonly OperationParam MessagingText = "text";
 
-        public static readonly OperationParam InboxMessageType = new OperationParam("inbox");
-        public static readonly OperationParam SentMessageType = new OperationParam("sent");
+        public static readonly OperationParam InboxMessageType = "inbox";
+        public static readonly OperationParam SentMessageType = "sent";
 
         // lobby
-        public static readonly OperationParam EntryId = new OperationParam("entryId");
-        public static readonly OperationParam LobbyRoomType = new OperationParam("lobbyType");
-        public static readonly OperationParam LobbyTypes = new OperationParam("lobbyTypes");
-        public static readonly OperationParam LobbyRating = new OperationParam("rating");
-        public static readonly OperationParam LobbyAlgorithm = new OperationParam("algo");
-        public static readonly OperationParam LobbyMaxSteps = new OperationParam("maxSteps");
-        public static readonly OperationParam LobbyStrategy = new OperationParam("strategy");
-        public static readonly OperationParam LobbyAlignment = new OperationParam("alignment");
-        public static readonly OperationParam LobbyRanges = new OperationParam("ranges");
-        public static readonly OperationParam LobbyFilterJson = new OperationParam("filterJson");
-        public static readonly OperationParam LobbySettings = new OperationParam("settings");
-        public static readonly OperationParam LobbyTimeoutSeconds = new OperationParam("timeoutSecs");
-        public static readonly OperationParam LobbyIsReady = new OperationParam("isReady");
-        public static readonly OperationParam LobbyOtherUserCxIds = new OperationParam("otherUserCxIds");
-        public static readonly OperationParam LobbyExtraJson = new OperationParam("extraJson");
-        public static readonly OperationParam LobbyTeamCode = new OperationParam("teamCode");
-        public static readonly OperationParam LobbyIdentifier = new OperationParam("lobbyId");
-        public static readonly OperationParam LobbyToTeamName = new OperationParam("toTeamCode");
-        public static readonly OperationParam LobbySignalData = new OperationParam("signalData");
-        public static readonly OperationParam LobbyConnectionId = new OperationParam("cxId");
-        public static readonly OperationParam PingData = new OperationParam("pingData");
-        public static readonly OperationParam LobbyMinRating = new OperationParam("minRating");
-        public static readonly OperationParam LobbyMaxRating = new OperationParam("maxRating");
+        public static readonly OperationParam EntryId = "entryId";
+        public static readonly OperationParam LobbyRoomType = "lobbyType";
+        public static readonly OperationParam LobbyTypes = "lobbyTypes";
+        public static readonly OperationParam LobbyRating = "rating";
+        public static readonly OperationParam LobbyAlgorithm = "algo";
+        public static readonly OperationParam LobbyMaxSteps = "maxSteps";
+        public static readonly OperationParam LobbyStrategy = "strategy";
+        public static readonly OperationParam LobbyAlignment = "alignment";
+        public static readonly OperationParam LobbyRanges = "ranges";
+        public static readonly OperationParam LobbyFilterJson = "filterJson";
+        public static readonly OperationParam LobbySettings = "settings";
+        public static readonly OperationParam LobbyTimeoutSeconds = "timeoutSecs";
+        public static readonly OperationParam LobbyIsReady = "isReady";
+        public static readonly OperationParam LobbyOtherUserCxIds = "otherUserCxIds";
+        public static readonly OperationParam LobbyExtraJson = "extraJson";
+        public static readonly OperationParam LobbyTeamCode = "teamCode";
+        public static readonly OperationParam LobbyIdentifier = "lobbyId";
+        public static readonly OperationParam LobbyToTeamName = "toTeamCode";
+        public static readonly OperationParam LobbySignalData = "signalData";
+        public static readonly OperationParam LobbyConnectionId = "cxId";
+        public static readonly OperationParam PingData = "pingData";
+        public static readonly OperationParam LobbyMinRating = "minRating";
+        public static readonly OperationParam LobbyMaxRating = "maxRating";
 
-        public static readonly OperationParam CompoundAlgos = new OperationParam("algos");
-        public static readonly OperationParam CompoundRanges = new OperationParam("compound-ranges");
-        public static readonly OperationParam LobbyCritera = new OperationParam("criteriaJson");
-        public static readonly OperationParam Critera = new OperationParam("criteria");
-        public static readonly OperationParam CriteraPing = new OperationParam("ping");
-        public static readonly OperationParam CriteraRating = new OperationParam("rating");
-        public static readonly OperationParam StrategyRangedPercent = new OperationParam("ranged-percent");
-        public static readonly OperationParam StrategyRangedAbsolute = new OperationParam("ranged-absolute");
-        public static readonly OperationParam StrategyAbsolute = new OperationParam("absolute");
-        public static readonly OperationParam StrategyCompound = new OperationParam("compound");
-        public static readonly OperationParam AlignmentCenter = new OperationParam("center");
+        public static readonly OperationParam CompoundAlgos = "algos";
+        public static readonly OperationParam CompoundRanges = "compound-ranges";
+        public static readonly OperationParam LobbyCritera = "criteriaJson";
+        public static readonly OperationParam Critera = "criteria";
+        public static readonly OperationParam CriteraPing = "ping";
+        public static readonly OperationParam CriteraRating = "rating";
+        public static readonly OperationParam StrategyRangedPercent = "ranged-percent";
+        public static readonly OperationParam StrategyRangedAbsolute = "ranged-absolute";
+        public static readonly OperationParam StrategyAbsolute = "absolute";
+        public static readonly OperationParam StrategyCompound = "compound";
+        public static readonly OperationParam AlignmentCenter = "center";
         //custom entity
-        public static readonly OperationParam CustomEntityServiceEntityType = new OperationParam("entityType");
-        public static readonly OperationParam CustomEntityServiceDeleteCriteria = new OperationParam("deleteCriteria");
-        public static readonly OperationParam CustomEntityServiceEntityId = new OperationParam("entityId");
-        public static readonly OperationParam CustomEntityServiceVersion = new OperationParam("version");
-        public static readonly OperationParam CustomEntityServiceFieldsJson = new OperationParam("fieldsJson");
-        public static readonly OperationParam CustomEntityServiceWhereJson = new OperationParam("whereJson");
-        public static readonly OperationParam CustomEntityServiceRowsPerPage = new OperationParam("rowsPerPage");
-        public static readonly OperationParam CustomEntityServiceSearchJson = new OperationParam("searchJson");
-        public static readonly OperationParam CustomEntityServiceSortJson = new OperationParam("sortJson");
-        public static readonly OperationParam CustomEntityServiceDoCount = new OperationParam("doCount");
-        public static readonly OperationParam CustomEntityServiceContext = new OperationParam("context");
-        public static readonly OperationParam CustomEntityServicePageOffset= new OperationParam("pageOffset");
-        public static readonly OperationParam CustomEntityServiceTimeToLive = new OperationParam("timeToLive");
-        public static readonly OperationParam CustomEntityServiceAcl = new OperationParam("acl");
-        public static readonly OperationParam CustomEntityServiceDataJson = new OperationParam("dataJson");
-        public static readonly OperationParam CustomEntityServiceIsOwned = new OperationParam("isOwned");
-        public static readonly OperationParam CustomEntityServiceMaxReturn = new OperationParam("maxReturn");
-        public static readonly OperationParam CustomEntityServiceShardKeyJson = new OperationParam("shardKeyJson");
+        public static readonly OperationParam CustomEntityServiceEntityType = "entityType";
+        public static readonly OperationParam CustomEntityServiceDeleteCriteria = "deleteCriteria";
+        public static readonly OperationParam CustomEntityServiceEntityId = "entityId";
+        public static readonly OperationParam CustomEntityServiceVersion = "version";
+        public static readonly OperationParam CustomEntityServiceFieldsJson = "fieldsJson";
+        public static readonly OperationParam CustomEntityServiceWhereJson = "whereJson";
+        public static readonly OperationParam CustomEntityServiceRowsPerPage = "rowsPerPage";
+        public static readonly OperationParam CustomEntityServiceSearchJson = "searchJson";
+        public static readonly OperationParam CustomEntityServiceSortJson = "sortJson";
+        public static readonly OperationParam CustomEntityServiceDoCount = "doCount";
+        public static readonly OperationParam CustomEntityServiceContext = "context";
+        public static readonly OperationParam CustomEntityServicePageOffset= "pageOffset";
+        public static readonly OperationParam CustomEntityServiceTimeToLive = "timeToLive";
+        public static readonly OperationParam CustomEntityServiceAcl = "acl";
+        public static readonly OperationParam CustomEntityServiceDataJson = "dataJson";
+        public static readonly OperationParam CustomEntityServiceIsOwned = "isOwned";
+        public static readonly OperationParam CustomEntityServiceMaxReturn = "maxReturn";
+        public static readonly OperationParam CustomEntityServiceShardKeyJson = "shardKeyJson";
 
         //item catalog
-        public static readonly OperationParam ItemCatalogServiceDefId = new OperationParam("defId");
-        public static readonly OperationParam ItemCatalogServiceContext = new OperationParam("context");
-        public static readonly OperationParam ItemCatalogServicePageOffset = new OperationParam("pageOffset");
+        public static readonly OperationParam ItemCatalogServiceDefId = "defId";
+        public static readonly OperationParam ItemCatalogServiceContext = "context";
+        public static readonly OperationParam ItemCatalogServicePageOffset = "pageOffset";
 
         //userInventory
-        public static readonly OperationParam UserItemsServiceDefId = new OperationParam("defId");
-        public static readonly OperationParam UserItemsServiceQuantity = new OperationParam("quantity");
-        public static readonly OperationParam UserItemsServiceIncludeDef = new OperationParam("includeDef");
-        public static readonly OperationParam UserItemsServiceItemId = new OperationParam("itemId");
-        public static readonly OperationParam UserItemsServiceCriteria = new OperationParam("criteria");
-        public static readonly OperationParam UserItemsServiceContext = new OperationParam("context");
-        public static readonly OperationParam UserItemsServicePageOffset = new OperationParam("pageOffset");
-        public static readonly OperationParam UserItemsServiceVersion = new OperationParam("version");
-        public static readonly OperationParam UserItemsServiceImmediate = new OperationParam("immediate");
-        public static readonly OperationParam UserItemsServiceProfileId = new OperationParam("profileId");
-        public static readonly OperationParam UserItemsServiceShopId = new OperationParam("shopId");
-        public static readonly OperationParam UserItemsServiceNewItemData = new OperationParam("newItemData");
+        public static readonly OperationParam UserItemsServiceDefId = "defId";
+        public static readonly OperationParam UserItemsServiceQuantity = "quantity";
+        public static readonly OperationParam UserItemsServiceIncludeDef = "includeDef";
+        public static readonly OperationParam UserItemsServiceItemId = "itemId";
+        public static readonly OperationParam UserItemsServiceCriteria = "criteria";
+        public static readonly OperationParam UserItemsServiceContext = "context";
+        public static readonly OperationParam UserItemsServicePageOffset = "pageOffset";
+        public static readonly OperationParam UserItemsServiceVersion = "version";
+        public static readonly OperationParam UserItemsServiceImmediate = "immediate";
+        public static readonly OperationParam UserItemsServiceProfileId = "profileId";
+        public static readonly OperationParam UserItemsServiceShopId = "shopId";
+        public static readonly OperationParam UserItemsServiceNewItemData = "newItemData";
 
         //global app
-        public static readonly OperationParam GlobalAppPropertyNames = new OperationParam("propertyNames");
-        public static readonly OperationParam GlobalAppCategories = new OperationParam("categories");
-        
+        public static readonly OperationParam GlobalAppPropertyNames = "propertyNames";
+        public static readonly OperationParam GlobalAppCategories = "categories";
+
+        #endregion
+
         private OperationParam(string value)
         {
             Value = value;
         }
 
-        public string Value
+        public string Value { get; private set; }
+
+        #region Overrides and Operators
+
+        public override bool Equals(object obj)
         {
-            get;
-            private set;
+            if (obj is not OperationParam c)
+                return false;
+
+            return Equals(c);
         }
+
+        public bool Equals(OperationParam other)
+        {
+            if (GetType() != other.GetType())
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Value == other.Value;
+        }
+
+        public int CompareTo(OperationParam other)
+        {
+            if (GetType() != other.GetType())
+                return 1;
+
+            if (ReferenceEquals(this, other))
+                return 0;
+
+            return Value.CompareTo(other.Value);
+        }
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override string ToString() => Value;
+
+        public static implicit operator string(OperationParam v) => v.Value;
+
+        public static implicit operator OperationParam(string v) => new(v);
+
+        public static bool operator ==(OperationParam v1, OperationParam v2) => v1.Equals(v2);
+
+        public static bool operator !=(OperationParam v1, OperationParam v2) => !(v1 == v2);
+
+        public static bool operator >(OperationParam v1, OperationParam v2) => v1.CompareTo(v2) == 1;
+
+        public static bool operator <(OperationParam v1, OperationParam v2) => v1.CompareTo(v2) == -1;
+
+        public static bool operator >=(OperationParam v1, OperationParam v2) => v1.CompareTo(v2) >= 0;
+
+        public static bool operator <=(OperationParam v1, OperationParam v2) => v1.CompareTo(v2) <= 0;
+
+        #endregion
     }
 }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceName.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceName.cs
@@ -6,65 +6,119 @@
 
 namespace BrainCloud
 {
-    public class ServiceName
+    public struct ServiceName : System.IEquatable<ServiceName>, System.IComparable<ServiceName>
     {
+        #region brainCloud Service Names
+
         // Services
-        public static readonly ServiceName AsyncMatch = new ServiceName("asyncMatch");
-        public static readonly ServiceName Authenticate = new ServiceName("authenticationV2");
-        public static readonly ServiceName DataStream = new ServiceName("dataStream");
-        public static readonly ServiceName Entity = new ServiceName("entity");
-        public static readonly ServiceName Event = new ServiceName("event");
-        public static readonly ServiceName File = new ServiceName("file");
-        public static readonly ServiceName Friend = new ServiceName("friend");
-        public static readonly ServiceName Gamification = new ServiceName("gamification");
-        public static readonly ServiceName GlobalApp = new ServiceName("globalApp");
-        public static readonly ServiceName GlobalEntity = new ServiceName("globalEntity");
-        public static readonly ServiceName GlobalStatistics = new ServiceName("globalGameStatistics");
-        public static readonly ServiceName Group = new ServiceName("group");
-        public static readonly ServiceName HeartBeat = new ServiceName("heartbeat");
-        public static readonly ServiceName Identity = new ServiceName("identity");
-        public static readonly ServiceName ItemCatalog = new ServiceName("itemCatalog");
-        public static readonly ServiceName UserItems = new ServiceName("userItems");
-        public static readonly ServiceName Mail = new ServiceName("mail");
-        public static readonly ServiceName MatchMaking = new ServiceName("matchMaking");
-        public static readonly ServiceName OneWayMatch = new ServiceName("onewayMatch");
-        public static readonly ServiceName PlaybackStream = new ServiceName("playbackStream");
-        public static readonly ServiceName PlayerState = new ServiceName("playerState");
-        public static readonly ServiceName PlayerStatistics = new ServiceName("playerStatistics");
-        public static readonly ServiceName PlayerStatisticsEvent = new ServiceName("playerStatisticsEvent");
-        public static readonly ServiceName Presence = new ServiceName("presence");
-        public static readonly ServiceName Profanity = new ServiceName("profanity");
-        public static readonly ServiceName PushNotification = new ServiceName("pushNotification");
-        public static readonly ServiceName RedemptionCode = new ServiceName("redemptionCode");
-        public static readonly ServiceName S3Handling = new ServiceName("s3Handling");
-        public static readonly ServiceName Script = new ServiceName("script");
-        public static readonly ServiceName ServerTime = new ServiceName("time");
-        public static readonly ServiceName Leaderboard = new ServiceName("leaderboard");
-        public static readonly ServiceName Twitter = new ServiceName("twitter");
-        public static readonly ServiceName Time = new ServiceName("time");
-        public static readonly ServiceName Tournament = new ServiceName("tournament");
-        public static readonly ServiceName GlobalFile = new ServiceName("globalFileV3");
-        public static readonly ServiceName CustomEntity = new ServiceName("customEntity");
-        public static readonly ServiceName RTTRegistration = new ServiceName("rttRegistration");
-        public static readonly ServiceName RTT = new ServiceName("rtt");
-        public static readonly ServiceName Relay = new ServiceName("relay");
-        public static readonly ServiceName Chat = new ServiceName("chat");
-        public static readonly ServiceName Messaging = new ServiceName("messaging");
-        public static readonly ServiceName Lobby = new ServiceName("lobby");
-        public static readonly ServiceName VirtualCurrency = new ServiceName("virtualCurrency");
-        public static readonly ServiceName AppStore = new ServiceName("appStore");
-        public static readonly ServiceName BlockChain = new ServiceName("blockchain");
-        public static readonly ServiceName GroupFile = new ServiceName("groupFile");
+        public static readonly ServiceName AsyncMatch = "asyncMatch";
+        public static readonly ServiceName Authenticate = "authenticationV2";
+        public static readonly ServiceName DataStream = "dataStream";
+        public static readonly ServiceName Entity = "entity";
+        public static readonly ServiceName Event = "event";
+        public static readonly ServiceName File = "file";
+        public static readonly ServiceName Friend = "friend";
+        public static readonly ServiceName Gamification = "gamification";
+        public static readonly ServiceName GlobalApp = "globalApp";
+        public static readonly ServiceName GlobalEntity = "globalEntity";
+        public static readonly ServiceName GlobalStatistics = "globalGameStatistics";
+        public static readonly ServiceName Group = "group";
+        public static readonly ServiceName HeartBeat = "heartbeat";
+        public static readonly ServiceName Identity = "identity";
+        public static readonly ServiceName ItemCatalog = "itemCatalog";
+        public static readonly ServiceName UserItems = "userItems";
+        public static readonly ServiceName Mail = "mail";
+        public static readonly ServiceName MatchMaking = "matchMaking";
+        public static readonly ServiceName OneWayMatch = "onewayMatch";
+        public static readonly ServiceName PlaybackStream = "playbackStream";
+        public static readonly ServiceName PlayerState = "playerState";
+        public static readonly ServiceName PlayerStatistics = "playerStatistics";
+        public static readonly ServiceName PlayerStatisticsEvent = "playerStatisticsEvent";
+        public static readonly ServiceName Presence = "presence";
+        public static readonly ServiceName Profanity = "profanity";
+        public static readonly ServiceName PushNotification = "pushNotification";
+        public static readonly ServiceName RedemptionCode = "redemptionCode";
+        public static readonly ServiceName S3Handling = "s3Handling";
+        public static readonly ServiceName Script = "script";
+        public static readonly ServiceName ServerTime = "time";
+        public static readonly ServiceName Leaderboard = "leaderboard";
+        public static readonly ServiceName Twitter = "twitter";
+        public static readonly ServiceName Time = "time";
+        public static readonly ServiceName Tournament = "tournament";
+        public static readonly ServiceName GlobalFile = "globalFileV3";
+        public static readonly ServiceName CustomEntity = "customEntity";
+        public static readonly ServiceName RTTRegistration = "rttRegistration";
+        public static readonly ServiceName RTT = "rtt";
+        public static readonly ServiceName Relay = "relay";
+        public static readonly ServiceName Chat = "chat";
+        public static readonly ServiceName Messaging = "messaging";
+        public static readonly ServiceName Lobby = "lobby";
+        public static readonly ServiceName VirtualCurrency = "virtualCurrency";
+        public static readonly ServiceName AppStore = "appStore";
+        public static readonly ServiceName BlockChain = "blockchain";
+        public static readonly ServiceName GroupFile = "groupFile";
+
+        #endregion
 
         private ServiceName(string value)
         {
             Value = value;
         }
 
-        public string Value
+        public string Value { get; private set; }
+
+        #region Overrides and Operators
+
+        public override bool Equals(object obj)
         {
-            get;
-            private set;
+            if (obj is not ServiceName c)
+                return false;
+
+            return Equals(c);
         }
+
+        public bool Equals(ServiceName other)
+        {
+            if (GetType() != other.GetType())
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Value == other.Value;
+        }
+
+        public int CompareTo(ServiceName other)
+        {
+            if (GetType() != other.GetType())
+                return 1;
+
+            if (ReferenceEquals(this, other))
+                return 0;
+
+            return Value.CompareTo(other.Value);
+        }
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override string ToString() => Value;
+
+        public static implicit operator string(ServiceName v) => v.Value;
+
+        public static implicit operator ServiceName(string v) => new(v);
+
+        public static bool operator ==(ServiceName v1, ServiceName v2) => v1.Equals(v2);
+
+        public static bool operator !=(ServiceName v1, ServiceName v2) => !(v1 == v2);
+
+        public static bool operator >(ServiceName v1, ServiceName v2) => v1.CompareTo(v2) == 1;
+
+        public static bool operator <(ServiceName v1, ServiceName v2) => v1.CompareTo(v2) == -1;
+
+        public static bool operator >=(ServiceName v1, ServiceName v2) => v1.CompareTo(v2) >= 0;
+
+        public static bool operator <=(ServiceName v1, ServiceName v2) => v1.CompareTo(v2) <= 0;
+
+        #endregion
     }
 }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
@@ -9,535 +9,583 @@ namespace BrainCloud
     /**
      * List of all available service operations. The values are mapped to server keys which represent that operation.
      */
-    public class ServiceOperation
+    public struct ServiceOperation : System.IEquatable<ServiceOperation>, System.IComparable<ServiceOperation>
     {
-        public static readonly ServiceOperation Authenticate = new ServiceOperation("AUTHENTICATE");
-        public static readonly ServiceOperation Attach = new ServiceOperation("ATTACH");
-        public static readonly ServiceOperation Merge = new ServiceOperation("MERGE");
-        public static readonly ServiceOperation Detach = new ServiceOperation("DETACH");
-        public static readonly ServiceOperation GetServerVersion = new ServiceOperation("GET_SERVER_VERSION");
-        public static readonly ServiceOperation ResetEmailPassword = new ServiceOperation("RESET_EMAIL_PASSWORD");
-        public static readonly ServiceOperation ResetEmailPasswordWithExpiry = new ServiceOperation("RESET_EMAIL_PASSWORD_WITH_EXPIRY");
-        public static readonly ServiceOperation ResetEmailPasswordAdvanced = new ServiceOperation("RESET_EMAIL_PASSWORD_ADVANCED");
-        public static readonly ServiceOperation ResetEmailPasswordAdvancedWithExpiry = new ServiceOperation("RESET_EMAIL_PASSWORD_ADVANCED_WITH_EXPIRY");
-        public static readonly ServiceOperation ResetUniversalIdPassword = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD");
-        public static readonly ServiceOperation ResetUniversalIdPasswordWithExpiry = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD_WITH_EXPIRY");
-        public static readonly ServiceOperation ResetUniversalIdPasswordAdvanced = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD_ADVANCED");
-        public static readonly ServiceOperation ResetUniversalIdPasswordAdvancedWithExpiry = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD_ADVANCED_WITH_EXPIRY");
-        public static readonly ServiceOperation SwitchToChildProfile = new ServiceOperation("SWITCH_TO_CHILD_PROFILE");
-        public static readonly ServiceOperation SwitchToParentProfile = new ServiceOperation("SWITCH_TO_PARENT_PROFILE");
-        public static readonly ServiceOperation DetachParent = new ServiceOperation("DETACH_PARENT");
-        public static readonly ServiceOperation AttachParentWithIdentity = new ServiceOperation("ATTACH_PARENT_WITH_IDENTITY");
-        public static readonly ServiceOperation AttachNonLoginUniversalId = new ServiceOperation("ATTACH_NONLOGIN_UNIVERSAL");
-        public static readonly ServiceOperation UpdateUniversalIdLogin = new ServiceOperation("UPDATE_UNIVERSAL_LOGIN");
-        public static readonly ServiceOperation GetIdentityStatus = new ServiceOperation("GET_IDENTITY_STATUS");
+        #region brainCloud Service Operations
 
-        public static readonly ServiceOperation AttachBlockChain = new ServiceOperation("ATTACH_BLOCKCHAIN_IDENTITY");
-        public static readonly ServiceOperation DetachBlockChain = new ServiceOperation("DETACH_BLOCKCHAIN_IDENTITY");
-        public static readonly ServiceOperation GetBlockchainItems = new ServiceOperation("GET_BLOCKCHAIN_ITEMS");
-        public static readonly ServiceOperation GetUniqs = new ServiceOperation("GET_UNIQS");
+        public static readonly ServiceOperation Authenticate = "AUTHENTICATE";
+        public static readonly ServiceOperation Attach = "ATTACH";
+        public static readonly ServiceOperation Merge = "MERGE";
+        public static readonly ServiceOperation Detach = "DETACH";
+        public static readonly ServiceOperation GetServerVersion = "GET_SERVER_VERSION";
+        public static readonly ServiceOperation ResetEmailPassword = "RESET_EMAIL_PASSWORD";
+        public static readonly ServiceOperation ResetEmailPasswordWithExpiry = "RESET_EMAIL_PASSWORD_WITH_EXPIRY";
+        public static readonly ServiceOperation ResetEmailPasswordAdvanced = "RESET_EMAIL_PASSWORD_ADVANCED";
+        public static readonly ServiceOperation ResetEmailPasswordAdvancedWithExpiry = "RESET_EMAIL_PASSWORD_ADVANCED_WITH_EXPIRY";
+        public static readonly ServiceOperation ResetUniversalIdPassword = "RESET_UNIVERSAL_ID_PASSWORD";
+        public static readonly ServiceOperation ResetUniversalIdPasswordWithExpiry = "RESET_UNIVERSAL_ID_PASSWORD_WITH_EXPIRY";
+        public static readonly ServiceOperation ResetUniversalIdPasswordAdvanced = "RESET_UNIVERSAL_ID_PASSWORD_ADVANCED";
+        public static readonly ServiceOperation ResetUniversalIdPasswordAdvancedWithExpiry = "RESET_UNIVERSAL_ID_PASSWORD_ADVANCED_WITH_EXPIRY";
+        public static readonly ServiceOperation SwitchToChildProfile = "SWITCH_TO_CHILD_PROFILE";
+        public static readonly ServiceOperation SwitchToParentProfile = "SWITCH_TO_PARENT_PROFILE";
+        public static readonly ServiceOperation DetachParent = "DETACH_PARENT";
+        public static readonly ServiceOperation AttachParentWithIdentity = "ATTACH_PARENT_WITH_IDENTITY";
+        public static readonly ServiceOperation AttachNonLoginUniversalId = "ATTACH_NONLOGIN_UNIVERSAL";
+        public static readonly ServiceOperation UpdateUniversalIdLogin = "UPDATE_UNIVERSAL_LOGIN";
+        public static readonly ServiceOperation GetIdentityStatus = "GET_IDENTITY_STATUS";
 
-        public static readonly ServiceOperation Create = new ServiceOperation("CREATE");
-        public static readonly ServiceOperation CreateWithIndexedId = new ServiceOperation("CREATE_WITH_INDEXED_ID");
-        public static readonly ServiceOperation Reset = new ServiceOperation("RESET");
-        public static readonly ServiceOperation Read = new ServiceOperation("READ");
-        public static readonly ServiceOperation ReadSingleton = new ServiceOperation("READ_SINGLETON");
-        public static readonly ServiceOperation ReadByType = new ServiceOperation("READ_BY_TYPE");
-        public static readonly ServiceOperation Verify = new ServiceOperation("VERIFY");
-        public static readonly ServiceOperation ReadShared = new ServiceOperation("READ_SHARED");
-        public static readonly ServiceOperation ReadSharedEntity = new ServiceOperation("READ_SHARED_ENTITY");
-        public static readonly ServiceOperation UpdateEntityIndexedId = new ServiceOperation("UPDATE_INDEXED_ID");
-        public static readonly ServiceOperation UpdateEntityOwnerAndAcl = new ServiceOperation("UPDATE_ENTITY_OWNER_AND_ACL");
-        public static readonly ServiceOperation MakeSystemEntity = new ServiceOperation("MAKE_SYSTEM_ENTITY");
+        public static readonly ServiceOperation AttachBlockChain = "ATTACH_BLOCKCHAIN_IDENTITY";
+        public static readonly ServiceOperation DetachBlockChain = "DETACH_BLOCKCHAIN_IDENTITY";
+        public static readonly ServiceOperation GetBlockchainItems = "GET_BLOCKCHAIN_ITEMS";
+        public static readonly ServiceOperation GetUniqs = "GET_UNIQS";
+
+        public static readonly ServiceOperation Create = "CREATE";
+        public static readonly ServiceOperation CreateWithIndexedId = "CREATE_WITH_INDEXED_ID";
+        public static readonly ServiceOperation Reset = "RESET";
+        public static readonly ServiceOperation Read = "READ";
+        public static readonly ServiceOperation ReadSingleton = "READ_SINGLETON";
+        public static readonly ServiceOperation ReadByType = "READ_BY_TYPE";
+        public static readonly ServiceOperation Verify = "VERIFY";
+        public static readonly ServiceOperation ReadShared = "READ_SHARED";
+        public static readonly ServiceOperation ReadSharedEntity = "READ_SHARED_ENTITY";
+        public static readonly ServiceOperation UpdateEntityIndexedId = "UPDATE_INDEXED_ID";
+        public static readonly ServiceOperation UpdateEntityOwnerAndAcl = "UPDATE_ENTITY_OWNER_AND_ACL";
+        public static readonly ServiceOperation MakeSystemEntity = "MAKE_SYSTEM_ENTITY";
 
         // push notification
-        public static readonly ServiceOperation DeregisterAll = new ServiceOperation("DEREGISTER_ALL");
-        public static readonly ServiceOperation Deregister = new ServiceOperation("DEREGISTER");
-        public static readonly ServiceOperation Register = new ServiceOperation("REGISTER");
-        public static readonly ServiceOperation SendSimple = new ServiceOperation("SEND_SIMPLE");
-        public static readonly ServiceOperation SendRich = new ServiceOperation("SEND_RICH");
-        public static readonly ServiceOperation SendRaw = new ServiceOperation("SEND_RAW");
-        public static readonly ServiceOperation SendRawBatch = new ServiceOperation("SEND_RAW_BATCH");
-        public static readonly ServiceOperation SendRawToGroup = new ServiceOperation("SEND_RAW_TO_GROUP");
-        public static readonly ServiceOperation SendTemplatedToGroup = new ServiceOperation("SEND_TEMPLATED_TO_GROUP");
-        public static readonly ServiceOperation SendNormalizedToGroup = new ServiceOperation("SEND_NORMALIZED_TO_GROUP");
-        public static readonly ServiceOperation SendNormalized = new ServiceOperation("SEND_NORMALIZED");
-        public static readonly ServiceOperation SendNormalizedBatch = new ServiceOperation("SEND_NORMALIZED_BATCH");
-        public static readonly ServiceOperation ScheduleRichNotification = new ServiceOperation("SCHEDULE_RICH_NOTIFICATION");
-        public static readonly ServiceOperation ScheduleNormalizedNotification = new ServiceOperation("SCHEDULE_NORMALIZED_NOTIFICATION");
+        public static readonly ServiceOperation DeregisterAll = "DEREGISTER_ALL";
+        public static readonly ServiceOperation Deregister = "DEREGISTER";
+        public static readonly ServiceOperation Register = "REGISTER";
+        public static readonly ServiceOperation SendSimple = "SEND_SIMPLE";
+        public static readonly ServiceOperation SendRich = "SEND_RICH";
+        public static readonly ServiceOperation SendRaw = "SEND_RAW";
+        public static readonly ServiceOperation SendRawBatch = "SEND_RAW_BATCH";
+        public static readonly ServiceOperation SendRawToGroup = "SEND_RAW_TO_GROUP";
+        public static readonly ServiceOperation SendTemplatedToGroup = "SEND_TEMPLATED_TO_GROUP";
+        public static readonly ServiceOperation SendNormalizedToGroup = "SEND_NORMALIZED_TO_GROUP";
+        public static readonly ServiceOperation SendNormalized = "SEND_NORMALIZED";
+        public static readonly ServiceOperation SendNormalizedBatch = "SEND_NORMALIZED_BATCH";
+        public static readonly ServiceOperation ScheduleRichNotification = "SCHEDULE_RICH_NOTIFICATION";
+        public static readonly ServiceOperation ScheduleNormalizedNotification = "SCHEDULE_NORMALIZED_NOTIFICATION";
 
-        public static readonly ServiceOperation ScheduleRawNotification = new ServiceOperation("SCHEDULE_RAW_NOTIFICATION");
+        public static readonly ServiceOperation ScheduleRawNotification = "SCHEDULE_RAW_NOTIFICATION";
 
-        public static readonly ServiceOperation FullReset = new ServiceOperation("FULL_PLAYER_RESET");
-        public static readonly ServiceOperation DataReset = new ServiceOperation("GAME_DATA_RESET");
+        public static readonly ServiceOperation FullReset = "FULL_PLAYER_RESET";
+        public static readonly ServiceOperation DataReset = "GAME_DATA_RESET";
 
-        public static readonly ServiceOperation ProcessStatistics = new ServiceOperation("PROCESS_STATISTICS");
-        public static readonly ServiceOperation Update = new ServiceOperation("UPDATE");
-        public static readonly ServiceOperation UpdateShared = new ServiceOperation("UPDATE_SHARED");
-        public static readonly ServiceOperation UpdateAcl = new ServiceOperation("UPDATE_ACL");
-        public static readonly ServiceOperation UpdateTimeToLive = new ServiceOperation("UPDATE_TIME_TO_LIVE");
-        public static readonly ServiceOperation UpdatePartial = new ServiceOperation("UPDATE_PARTIAL");
-        public static readonly ServiceOperation UpdateSingleton = new ServiceOperation("UPDATE_SINGLETON");
-        public static readonly ServiceOperation Delete = new ServiceOperation("DELETE");
-        public static readonly ServiceOperation DeleteSingleton = new ServiceOperation("DELETE_SINGLETON");
-        public static readonly ServiceOperation UpdateSummary = new ServiceOperation("UPDATE_SUMMARY");
-        public static readonly ServiceOperation UpdateSetMinimum = new ServiceOperation("UPDATE_SET_MINIMUM");
-        public static readonly ServiceOperation UpdateIncrementToMaximum = new ServiceOperation("UPDATE_INCREMENT_TO_MAXIMUM");
-        public static readonly ServiceOperation GetFriendProfileInfoForExternalId = new ServiceOperation("GET_FRIEND_PROFILE_INFO_FOR_EXTERNAL_ID");
-        public static readonly ServiceOperation GetProfileInfoForCredential = new ServiceOperation("GET_PROFILE_INFO_FOR_CREDENTIAL");
-        public static readonly ServiceOperation GetProfileInfoForCredentialIfExists = new ServiceOperation("GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS");
-        public static readonly ServiceOperation GetProfileInfoForExternalAuthId = new ServiceOperation("GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID");
-        public static readonly ServiceOperation GetProfileInfoForExternalAuthIdIfExists = new ServiceOperation("GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS");
-        public static readonly ServiceOperation GetExternalIdForProfileId = new ServiceOperation("GET_EXTERNAL_ID_FOR_PROFILE_ID");
-        public static readonly ServiceOperation FindPlayerByUniversalId = new ServiceOperation("FIND_PLAYER_BY_UNIVERSAL_ID");
-        public static readonly ServiceOperation FindUserByExactUniversalId = new ServiceOperation("FIND_USER_BY_EXACT_UNIVERSAL_ID");
-        public static readonly ServiceOperation FindUsersByNameStartingWith = new ServiceOperation("FIND_USERS_BY_NAME_STARTING_WITH");
-        public static readonly ServiceOperation FindUsersByUniversalIdStartingWith = new ServiceOperation("FIND_USERS_BY_UNIVERSAL_ID_STARTING_WITH");
-        public static readonly ServiceOperation ReadFriends = new ServiceOperation("READ_FRIENDS");
-        public static readonly ServiceOperation ReadFriendEntity = new ServiceOperation("READ_FRIEND_ENTITY");
-        public static readonly ServiceOperation ReadFriendsEntities = new ServiceOperation("READ_FRIENDS_ENTITIES");
-        public static readonly ServiceOperation ReadFriendsWithApplication = new ServiceOperation("READ_FRIENDS_WITH_APPLICATION");
-        public static readonly ServiceOperation ReadFriendPlayerState = new ServiceOperation("READ_FRIEND_PLAYER_STATE");
-        public static readonly ServiceOperation GetSummaryDataForProfileId = new ServiceOperation("GET_SUMMARY_DATA_FOR_PROFILE_ID");
-        public static readonly ServiceOperation FindPlayerByName = new ServiceOperation("FIND_PLAYER_BY_NAME");
-        public static readonly ServiceOperation FindUsersByExactName = new ServiceOperation("FIND_USERS_BY_EXACT_NAME");
-        public static readonly ServiceOperation FindUsersBySubstrName = new ServiceOperation("FIND_USERS_BY_SUBSTR_NAME");
-        public static readonly ServiceOperation ListFriends = new ServiceOperation("LIST_FRIENDS");
-        public static readonly ServiceOperation GetMySocialInfo = new ServiceOperation("GET_MY_SOCIAL_INFO");
-        public static readonly ServiceOperation AddFriends = new ServiceOperation("ADD_FRIENDS");
-        public static readonly ServiceOperation AddFriendsFromPlatform = new ServiceOperation("ADD_FRIENDS_FROM_PLATFORM");
-        public static readonly ServiceOperation RemoveFriends = new ServiceOperation("REMOVE_FRIENDS");
-        public static readonly ServiceOperation GetUsersOnlineStatus = new ServiceOperation("GET_USERS_ONLINE_STATUS");
-        public static readonly ServiceOperation GetSocialLeaderboard = new ServiceOperation("GET_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetSocialLeaderboardIfExists = new ServiceOperation("GET_SOCIAL_LEADERBOARD_IF_EXISTS");
-        public static readonly ServiceOperation GetSocialLeaderboardByVersion = new ServiceOperation("GET_SOCIAL_LEADERBOARD_BY_VERSION");
-        public static readonly ServiceOperation GetSocialLeaderboardByVersionIfExists = new ServiceOperation("GET_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS");
-        public static readonly ServiceOperation GetMultiSocialLeaderboard = new ServiceOperation("GET_MULTI_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetGlobalLeaderboard = new ServiceOperation("GET_GLOBAL_LEADERBOARD");
-        public static readonly ServiceOperation GetGlobalLeaderboardPage = new ServiceOperation("GET_GLOBAL_LEADERBOARD_PAGE");
-        public static readonly ServiceOperation GetGlobalLeaderboardPageIfExists = new ServiceOperation("GET_GLOBAL_LEADERBOARD_PAGE_IF_EXISTS");
-        public static readonly ServiceOperation GetGlobalLeaderboardView = new ServiceOperation("GET_GLOBAL_LEADERBOARD_VIEW");
-        public static readonly ServiceOperation GetGlobalLeaderboardViewIfExists = new ServiceOperation("GET_GLOBAL_LEADERBOARD_VIEW_IF_EXISTS");
-        public static readonly ServiceOperation GetGlobalLeaderboardVersions = new ServiceOperation("GET_GLOBAL_LEADERBOARD_VERSIONS");
-        public static readonly ServiceOperation PostScore = new ServiceOperation("POST_SCORE");
-        public static readonly ServiceOperation PostScoreDynamic = new ServiceOperation("POST_SCORE_DYNAMIC");
-        public static readonly ServiceOperation PostScoreDynamicUsingConfig = new ServiceOperation("POST_SCORE_DYNAMIC_USING_CONFIG");
-        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboard = new ServiceOperation("POST_GROUP_SCORE_DYNAMIC");
-        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboardUsingConfig = new ServiceOperation("POST_GROUP_SCORE_DYNAMIC_USING_CONFIG");
-        public static readonly ServiceOperation RemovePlayerScore = new ServiceOperation("REMOVE_PLAYER_SCORE");
-        public static readonly ServiceOperation GetCompletedTournament = new ServiceOperation("GET_COMPLETED_TOURNAMENT");
-        public static readonly ServiceOperation RewardTournament = new ServiceOperation("REWARD_TOURNAMENT");
-        public static readonly ServiceOperation GetGroupSocialLeaderboard = new ServiceOperation("GET_GROUP_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetGroupSocialLeaderboardByVersion = new ServiceOperation("GET_GROUP_SOCIAL_LEADERBOARD_BY_VERSION");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboard = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboardIfExists = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD_IF_EXISTS");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersion = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersionIfExists = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS");
-        public static readonly ServiceOperation ListAllLeaderboards = new ServiceOperation("LIST_ALL_LEADERBOARDS");
-        public static readonly ServiceOperation GetGlobalLeaderboardEntryCount = new ServiceOperation("GET_GLOBAL_LEADERBOARD_ENTRY_COUNT");
-        public static readonly ServiceOperation GetPlayerScore = new ServiceOperation("GET_PLAYER_SCORE");
-        public static readonly ServiceOperation GetPlayerScores = new ServiceOperation("GET_PLAYER_SCORES");
-        public static readonly ServiceOperation GetPlayerScoresFromLeaderboards = new ServiceOperation("GET_PLAYER_SCORES_FROM_LEADERBOARDS");
-        public static readonly ServiceOperation PostScoreToGroupLeaderboard = new ServiceOperation("POST_GROUP_SCORE");
-        public static readonly ServiceOperation RemoveGroupScore = new ServiceOperation("REMOVE_GROUP_SCORE");
-        public static readonly ServiceOperation GetGroupLeaderboardView = new ServiceOperation("GET_GROUP_LEADERBOARD_VIEW");
+        public static readonly ServiceOperation ProcessStatistics = "PROCESS_STATISTICS";
+        public static readonly ServiceOperation Update = "UPDATE";
+        public static readonly ServiceOperation UpdateShared = "UPDATE_SHARED";
+        public static readonly ServiceOperation UpdateAcl = "UPDATE_ACL";
+        public static readonly ServiceOperation UpdateTimeToLive = "UPDATE_TIME_TO_LIVE";
+        public static readonly ServiceOperation UpdatePartial = "UPDATE_PARTIAL";
+        public static readonly ServiceOperation UpdateSingleton = "UPDATE_SINGLETON";
+        public static readonly ServiceOperation Delete = "DELETE";
+        public static readonly ServiceOperation DeleteSingleton = "DELETE_SINGLETON";
+        public static readonly ServiceOperation UpdateSummary = "UPDATE_SUMMARY";
+        public static readonly ServiceOperation UpdateSetMinimum = "UPDATE_SET_MINIMUM";
+        public static readonly ServiceOperation UpdateIncrementToMaximum = "UPDATE_INCREMENT_TO_MAXIMUM";
+        public static readonly ServiceOperation GetFriendProfileInfoForExternalId = "GET_FRIEND_PROFILE_INFO_FOR_EXTERNAL_ID";
+        public static readonly ServiceOperation GetProfileInfoForCredential = "GET_PROFILE_INFO_FOR_CREDENTIAL";
+        public static readonly ServiceOperation GetProfileInfoForCredentialIfExists = "GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS";
+        public static readonly ServiceOperation GetProfileInfoForExternalAuthId = "GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID";
+        public static readonly ServiceOperation GetProfileInfoForExternalAuthIdIfExists = "GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS";
+        public static readonly ServiceOperation GetExternalIdForProfileId = "GET_EXTERNAL_ID_FOR_PROFILE_ID";
+        public static readonly ServiceOperation FindPlayerByUniversalId = "FIND_PLAYER_BY_UNIVERSAL_ID";
+        public static readonly ServiceOperation FindUserByExactUniversalId = "FIND_USER_BY_EXACT_UNIVERSAL_ID";
+        public static readonly ServiceOperation FindUsersByNameStartingWith = "FIND_USERS_BY_NAME_STARTING_WITH";
+        public static readonly ServiceOperation FindUsersByUniversalIdStartingWith = "FIND_USERS_BY_UNIVERSAL_ID_STARTING_WITH";
+        public static readonly ServiceOperation ReadFriends = "READ_FRIENDS";
+        public static readonly ServiceOperation ReadFriendEntity = "READ_FRIEND_ENTITY";
+        public static readonly ServiceOperation ReadFriendsEntities = "READ_FRIENDS_ENTITIES";
+        public static readonly ServiceOperation ReadFriendsWithApplication = "READ_FRIENDS_WITH_APPLICATION";
+        public static readonly ServiceOperation ReadFriendPlayerState = "READ_FRIEND_PLAYER_STATE";
+        public static readonly ServiceOperation GetSummaryDataForProfileId = "GET_SUMMARY_DATA_FOR_PROFILE_ID";
+        public static readonly ServiceOperation FindPlayerByName = "FIND_PLAYER_BY_NAME";
+        public static readonly ServiceOperation FindUsersByExactName = "FIND_USERS_BY_EXACT_NAME";
+        public static readonly ServiceOperation FindUsersBySubstrName = "FIND_USERS_BY_SUBSTR_NAME";
+        public static readonly ServiceOperation ListFriends = "LIST_FRIENDS";
+        public static readonly ServiceOperation GetMySocialInfo = "GET_MY_SOCIAL_INFO";
+        public static readonly ServiceOperation AddFriends = "ADD_FRIENDS";
+        public static readonly ServiceOperation AddFriendsFromPlatform = "ADD_FRIENDS_FROM_PLATFORM";
+        public static readonly ServiceOperation RemoveFriends = "REMOVE_FRIENDS";
+        public static readonly ServiceOperation GetUsersOnlineStatus = "GET_USERS_ONLINE_STATUS";
+        public static readonly ServiceOperation GetSocialLeaderboard = "GET_SOCIAL_LEADERBOARD";
+        public static readonly ServiceOperation GetSocialLeaderboardIfExists = "GET_SOCIAL_LEADERBOARD_IF_EXISTS";
+        public static readonly ServiceOperation GetSocialLeaderboardByVersion = "GET_SOCIAL_LEADERBOARD_BY_VERSION";
+        public static readonly ServiceOperation GetSocialLeaderboardByVersionIfExists = "GET_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS";
+        public static readonly ServiceOperation GetMultiSocialLeaderboard = "GET_MULTI_SOCIAL_LEADERBOARD";
+        public static readonly ServiceOperation GetGlobalLeaderboard = "GET_GLOBAL_LEADERBOARD";
+        public static readonly ServiceOperation GetGlobalLeaderboardPage = "GET_GLOBAL_LEADERBOARD_PAGE";
+        public static readonly ServiceOperation GetGlobalLeaderboardPageIfExists = "GET_GLOBAL_LEADERBOARD_PAGE_IF_EXISTS";
+        public static readonly ServiceOperation GetGlobalLeaderboardView = "GET_GLOBAL_LEADERBOARD_VIEW";
+        public static readonly ServiceOperation GetGlobalLeaderboardViewIfExists = "GET_GLOBAL_LEADERBOARD_VIEW_IF_EXISTS";
+        public static readonly ServiceOperation GetGlobalLeaderboardVersions = "GET_GLOBAL_LEADERBOARD_VERSIONS";
+        public static readonly ServiceOperation PostScore = "POST_SCORE";
+        public static readonly ServiceOperation PostScoreDynamic = "POST_SCORE_DYNAMIC";
+        public static readonly ServiceOperation PostScoreDynamicUsingConfig = "POST_SCORE_DYNAMIC_USING_CONFIG";
+        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboard = "POST_GROUP_SCORE_DYNAMIC";
+        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboardUsingConfig = "POST_GROUP_SCORE_DYNAMIC_USING_CONFIG";
+        public static readonly ServiceOperation RemovePlayerScore = "REMOVE_PLAYER_SCORE";
+        public static readonly ServiceOperation GetCompletedTournament = "GET_COMPLETED_TOURNAMENT";
+        public static readonly ServiceOperation RewardTournament = "REWARD_TOURNAMENT";
+        public static readonly ServiceOperation GetGroupSocialLeaderboard = "GET_GROUP_SOCIAL_LEADERBOARD";
+        public static readonly ServiceOperation GetGroupSocialLeaderboardByVersion = "GET_GROUP_SOCIAL_LEADERBOARD_BY_VERSION";
+        public static readonly ServiceOperation GetPlayersSocialLeaderboard = "GET_PLAYERS_SOCIAL_LEADERBOARD";
+        public static readonly ServiceOperation GetPlayersSocialLeaderboardIfExists = "GET_PLAYERS_SOCIAL_LEADERBOARD_IF_EXISTS";
+        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersion = "GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION";
+        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersionIfExists = "GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS";
+        public static readonly ServiceOperation ListAllLeaderboards = "LIST_ALL_LEADERBOARDS";
+        public static readonly ServiceOperation GetGlobalLeaderboardEntryCount = "GET_GLOBAL_LEADERBOARD_ENTRY_COUNT";
+        public static readonly ServiceOperation GetPlayerScore = "GET_PLAYER_SCORE";
+        public static readonly ServiceOperation GetPlayerScores = "GET_PLAYER_SCORES";
+        public static readonly ServiceOperation GetPlayerScoresFromLeaderboards = "GET_PLAYER_SCORES_FROM_LEADERBOARDS";
+        public static readonly ServiceOperation PostScoreToGroupLeaderboard = "POST_GROUP_SCORE";
+        public static readonly ServiceOperation RemoveGroupScore = "REMOVE_GROUP_SCORE";
+        public static readonly ServiceOperation GetGroupLeaderboardView = "GET_GROUP_LEADERBOARD_VIEW";
 
-        public static readonly ServiceOperation ReadFriendsPlayerState = new ServiceOperation("READ_FRIEND_PLAYER_STATE");
+        public static readonly ServiceOperation ReadFriendsPlayerState = "READ_FRIEND_PLAYER_STATE";
 
-        public static readonly ServiceOperation InitThirdParty = new ServiceOperation("initThirdParty");
-        public static readonly ServiceOperation PostThirdPartyLeaderboardScore = new ServiceOperation("postThirdPartyLeaderboardScore");
-        public static readonly ServiceOperation IncrementThirdPartyLeaderboardScore = new ServiceOperation("incrementThirdPartyLeaderboardScore");
-        public static readonly ServiceOperation LaunchAchievementUI = new ServiceOperation("launchAchievementUI");
-        public static readonly ServiceOperation PostThirdPartyLeaderboardAchievement = new ServiceOperation("postThirdPartyLeaderboardAchievement");
-        public static readonly ServiceOperation IsThirdPartyAchievementComplete = new ServiceOperation("isThirdPartyAchievementComplete");
-        public static readonly ServiceOperation ResetThirdPartyAchievements = new ServiceOperation("resetThirdPartyAchievements");
-        public static readonly ServiceOperation QueryThirdPartyAchievements = new ServiceOperation("queryThirdPartyAchievements");
+        public static readonly ServiceOperation InitThirdParty = "initThirdParty";
+        public static readonly ServiceOperation PostThirdPartyLeaderboardScore = "postThirdPartyLeaderboardScore";
+        public static readonly ServiceOperation IncrementThirdPartyLeaderboardScore = "incrementThirdPartyLeaderboardScore";
+        public static readonly ServiceOperation LaunchAchievementUI = "launchAchievementUI";
+        public static readonly ServiceOperation PostThirdPartyLeaderboardAchievement = "postThirdPartyLeaderboardAchievement";
+        public static readonly ServiceOperation IsThirdPartyAchievementComplete = "isThirdPartyAchievementComplete";
+        public static readonly ServiceOperation ResetThirdPartyAchievements = "resetThirdPartyAchievements";
+        public static readonly ServiceOperation QueryThirdPartyAchievements = "queryThirdPartyAchievements";
 
-        public static readonly ServiceOperation GetInventory = new ServiceOperation("GET_INVENTORY");
-        public static readonly ServiceOperation CashInReceipt = new ServiceOperation("OP_CASH_IN_RECEIPT");
-        public static readonly ServiceOperation AwardVC = new ServiceOperation("AWARD_VC");
-        public static readonly ServiceOperation ConsumePlayerVC = new ServiceOperation("CONSUME_VC");
-        public static readonly ServiceOperation GetPlayerVC = new ServiceOperation("GET_PLAYER_VC");
-        public static readonly ServiceOperation ResetPlayerVC = new ServiceOperation("RESET_PLAYER_VC");
+        public static readonly ServiceOperation GetInventory = "GET_INVENTORY";
+        public static readonly ServiceOperation CashInReceipt = "OP_CASH_IN_RECEIPT";
+        public static readonly ServiceOperation AwardVC = "AWARD_VC";
+        public static readonly ServiceOperation ConsumePlayerVC = "CONSUME_VC";
+        public static readonly ServiceOperation GetPlayerVC = "GET_PLAYER_VC";
+        public static readonly ServiceOperation ResetPlayerVC = "RESET_PLAYER_VC";
 
-        public static readonly ServiceOperation AwardParentCurrency = new ServiceOperation("AWARD_PARENT_VC");
-        public static readonly ServiceOperation ConsumeParentCurrency = new ServiceOperation("CONSUME_PARENT_VC");
-        public static readonly ServiceOperation GetParentVC = new ServiceOperation("GET_PARENT_VC");
-        public static readonly ServiceOperation ResetParentCurrency = new ServiceOperation("RESET_PARENT_VC");
+        public static readonly ServiceOperation AwardParentCurrency = "AWARD_PARENT_VC";
+        public static readonly ServiceOperation ConsumeParentCurrency = "CONSUME_PARENT_VC";
+        public static readonly ServiceOperation GetParentVC = "GET_PARENT_VC";
+        public static readonly ServiceOperation ResetParentCurrency = "RESET_PARENT_VC";
 
-        public static readonly ServiceOperation GetPeerVC = new ServiceOperation("GET_PEER_VC");
-        public static readonly ServiceOperation StartPurchase = new ServiceOperation("START_PURCHASE");
-        public static readonly ServiceOperation FinalizePurchase = new ServiceOperation("FINALIZE_PURCHASE");
-        public static readonly ServiceOperation RefreshPromotions = new ServiceOperation("REFRESH_PROMOTIONS");
+        public static readonly ServiceOperation GetPeerVC = "GET_PEER_VC";
+        public static readonly ServiceOperation StartPurchase = "START_PURCHASE";
+        public static readonly ServiceOperation FinalizePurchase = "FINALIZE_PURCHASE";
+        public static readonly ServiceOperation RefreshPromotions = "REFRESH_PROMOTIONS";
 
-        public static readonly ServiceOperation Send = new ServiceOperation("SEND");
-        public static readonly ServiceOperation SendToProfiles = new ServiceOperation("SEND_EVENT_TO_PROFILES");
-        public static readonly ServiceOperation UpdateEventData = new ServiceOperation("UPDATE_EVENT_DATA");
-        public static readonly ServiceOperation UpdateEventDataIfExists = new ServiceOperation("UPDATE_EVENT_DATA_IF_EXISTS");
-        public static readonly ServiceOperation DeleteSent = new ServiceOperation("DELETE_SENT");
-        public static readonly ServiceOperation DeleteIncoming = new ServiceOperation("DELETE_INCOMING");
-        public static readonly ServiceOperation DeleteIncomingEvents = new ServiceOperation("DELETE_INCOMING_EVENTS");
-        public static readonly ServiceOperation DeleteIncomingEventsOlderThan = new ServiceOperation("DELETE_INCOMING_EVENTS_OLDER_THAN");
-        public static readonly ServiceOperation DeleteIncomingEventsByTypeOlderThan = new ServiceOperation("DELETE_INCOMING_EVENTS_BY_TYPE_OLDER_THAN");
-        public static readonly ServiceOperation GetEvents = new ServiceOperation("GET_EVENTS");
+        public static readonly ServiceOperation Send = "SEND";
+        public static readonly ServiceOperation SendToProfiles = "SEND_EVENT_TO_PROFILES";
+        public static readonly ServiceOperation UpdateEventData = "UPDATE_EVENT_DATA";
+        public static readonly ServiceOperation UpdateEventDataIfExists = "UPDATE_EVENT_DATA_IF_EXISTS";
+        public static readonly ServiceOperation DeleteSent = "DELETE_SENT";
+        public static readonly ServiceOperation DeleteIncoming = "DELETE_INCOMING";
+        public static readonly ServiceOperation DeleteIncomingEvents = "DELETE_INCOMING_EVENTS";
+        public static readonly ServiceOperation DeleteIncomingEventsOlderThan = "DELETE_INCOMING_EVENTS_OLDER_THAN";
+        public static readonly ServiceOperation DeleteIncomingEventsByTypeOlderThan = "DELETE_INCOMING_EVENTS_BY_TYPE_OLDER_THAN";
+        public static readonly ServiceOperation GetEvents = "GET_EVENTS";
 
-        public static readonly ServiceOperation UpdateIncrement = new ServiceOperation("UPDATE_INCREMENT");
-        public static readonly ServiceOperation ReadNextXpLevel = new ServiceOperation("READ_NEXT_XPLEVEL");
-        public static readonly ServiceOperation ReadXpLevels = new ServiceOperation("READ_XP_LEVELS");
-        public static readonly ServiceOperation SetXpPoints = new ServiceOperation("SET_XPPOINTS");
-        public static readonly ServiceOperation ReadSubset = new ServiceOperation("READ_SUBSET");
+        public static readonly ServiceOperation UpdateIncrement = "UPDATE_INCREMENT";
+        public static readonly ServiceOperation ReadNextXpLevel = "READ_NEXT_XPLEVEL";
+        public static readonly ServiceOperation ReadXpLevels = "READ_XP_LEVELS";
+        public static readonly ServiceOperation SetXpPoints = "SET_XPPOINTS";
+        public static readonly ServiceOperation ReadSubset = "READ_SUBSET";
 
         //GlobalFile
-        public static readonly ServiceOperation GetFileInfo = new ServiceOperation("GET_FILE_INFO");
-        public static readonly ServiceOperation GetFileInfoSimple = new ServiceOperation("GET_FILE_INFO_SIMPLE");
-        public static readonly ServiceOperation GetGlobalCDNUrl = new ServiceOperation("GET_GLOBAL_CDN_URL");
-        public static readonly ServiceOperation GetGlobalFileList = new ServiceOperation("GET_GLOBAL_FILE_LIST");
+        public static readonly ServiceOperation GetFileInfo = "GET_FILE_INFO";
+        public static readonly ServiceOperation GetFileInfoSimple = "GET_FILE_INFO_SIMPLE";
+        public static readonly ServiceOperation GetGlobalCDNUrl = "GET_GLOBAL_CDN_URL";
+        public static readonly ServiceOperation GetGlobalFileList = "GET_GLOBAL_FILE_LIST";
 
-        public static readonly ServiceOperation Run = new ServiceOperation("RUN");
-        public static readonly ServiceOperation Tweet = new ServiceOperation("TWEET");
+        public static readonly ServiceOperation Run = "RUN";
+        public static readonly ServiceOperation Tweet = "TWEET";
 
-        public static readonly ServiceOperation AwardAchievements = new ServiceOperation("AWARD_ACHIEVEMENTS");
-        public static readonly ServiceOperation ReadAchievements = new ServiceOperation("READ_ACHIEVEMENTS");
-        public static readonly ServiceOperation ReadAchievedAchievements = new ServiceOperation("READ_ACHIEVED_ACHIEVEMENTS");
+        public static readonly ServiceOperation AwardAchievements = "AWARD_ACHIEVEMENTS";
+        public static readonly ServiceOperation ReadAchievements = "READ_ACHIEVEMENTS";
+        public static readonly ServiceOperation ReadAchievedAchievements = "READ_ACHIEVED_ACHIEVEMENTS";
 
-        public static readonly ServiceOperation SetPlayerRating = new ServiceOperation("SET_PLAYER_RATING");
-        public static readonly ServiceOperation ResetPlayerRating = new ServiceOperation("RESET_PLAYER_RATING");
-        public static readonly ServiceOperation IncrementPlayerRating = new ServiceOperation("INCREMENT_PLAYER_RATING");
-        public static readonly ServiceOperation DecrementPlayerRating = new ServiceOperation("DECREMENT_PLAYER_RATING");
-        public static readonly ServiceOperation ShieldOn = new ServiceOperation("SHIELD_ON");
-        public static readonly ServiceOperation ShieldOnFor = new ServiceOperation("SHIELD_ON_FOR");
-        public static readonly ServiceOperation ShieldOff = new ServiceOperation("SHIELD_OFF");
-        public static readonly ServiceOperation IncrementShieldOnFor = new ServiceOperation("INCREMENT_SHIELD_ON_FOR");
-        public static readonly ServiceOperation GetShieldExpiry = new ServiceOperation("GET_SHIELD_EXPIRY");
-        public static readonly ServiceOperation FindPlayers = new ServiceOperation("FIND_PLAYERS");
-        public static readonly ServiceOperation FindPlayersUsingFilter = new ServiceOperation("FIND_PLAYERS_USING_FILTER");
+        public static readonly ServiceOperation SetPlayerRating = "SET_PLAYER_RATING";
+        public static readonly ServiceOperation ResetPlayerRating = "RESET_PLAYER_RATING";
+        public static readonly ServiceOperation IncrementPlayerRating = "INCREMENT_PLAYER_RATING";
+        public static readonly ServiceOperation DecrementPlayerRating = "DECREMENT_PLAYER_RATING";
+        public static readonly ServiceOperation ShieldOn = "SHIELD_ON";
+        public static readonly ServiceOperation ShieldOnFor = "SHIELD_ON_FOR";
+        public static readonly ServiceOperation ShieldOff = "SHIELD_OFF";
+        public static readonly ServiceOperation IncrementShieldOnFor = "INCREMENT_SHIELD_ON_FOR";
+        public static readonly ServiceOperation GetShieldExpiry = "GET_SHIELD_EXPIRY";
+        public static readonly ServiceOperation FindPlayers = "FIND_PLAYERS";
+        public static readonly ServiceOperation FindPlayersUsingFilter = "FIND_PLAYERS_USING_FILTER";
 
-        public static readonly ServiceOperation SubmitTurn = new ServiceOperation("SUBMIT_TURN");
-        public static readonly ServiceOperation UpdateMatchSummary = new ServiceOperation("UPDATE_SUMMARY");
-        public static readonly ServiceOperation UpdateMatchStateCurrentTurn = new ServiceOperation("UPDATE_MATCH_STATE_CURRENT_TURN");
-        public static readonly ServiceOperation Abandon = new ServiceOperation("ABANDON");
-        public static readonly ServiceOperation AbandonMatchWithSummaryData = new ServiceOperation("ABANDON_MATCH_WITH_SUMMARY_DATA");
-        public static readonly ServiceOperation CompleteMatchWithSummaryData = new ServiceOperation("COMPLETE_MATCH_WITH_SUMMARY_DATA");
-        public static readonly ServiceOperation Complete = new ServiceOperation("COMPLETE");
-        public static readonly ServiceOperation ReadMatch = new ServiceOperation("READ_MATCH");
-        public static readonly ServiceOperation ReadMatchHistory = new ServiceOperation("READ_MATCH_HISTORY");
-        public static readonly ServiceOperation FindMatches = new ServiceOperation("FIND_MATCHES");
-        public static readonly ServiceOperation FindMatchesCompleted = new ServiceOperation("FIND_MATCHES_COMPLETED");
-        public static readonly ServiceOperation DeleteMatch = new ServiceOperation("DELETE_MATCH");
+        public static readonly ServiceOperation SubmitTurn = "SUBMIT_TURN";
+        public static readonly ServiceOperation UpdateMatchSummary = "UPDATE_SUMMARY";
+        public static readonly ServiceOperation UpdateMatchStateCurrentTurn = "UPDATE_MATCH_STATE_CURRENT_TURN";
+        public static readonly ServiceOperation Abandon = "ABANDON";
+        public static readonly ServiceOperation AbandonMatchWithSummaryData = "ABANDON_MATCH_WITH_SUMMARY_DATA";
+        public static readonly ServiceOperation CompleteMatchWithSummaryData = "COMPLETE_MATCH_WITH_SUMMARY_DATA";
+        public static readonly ServiceOperation Complete = "COMPLETE";
+        public static readonly ServiceOperation ReadMatch = "READ_MATCH";
+        public static readonly ServiceOperation ReadMatchHistory = "READ_MATCH_HISTORY";
+        public static readonly ServiceOperation FindMatches = "FIND_MATCHES";
+        public static readonly ServiceOperation FindMatchesCompleted = "FIND_MATCHES_COMPLETED";
+        public static readonly ServiceOperation DeleteMatch = "DELETE_MATCH";
 
-        public static readonly ServiceOperation LastUploadStatus = new ServiceOperation("LAST_UPLOAD_STATUS");
+        public static readonly ServiceOperation LastUploadStatus = "LAST_UPLOAD_STATUS";
 
-        public static readonly ServiceOperation ReadQuests = new ServiceOperation("READ_QUESTS");
-        public static readonly ServiceOperation ReadCompletedQuests = new ServiceOperation("READ_COMPLETED_QUESTS");
-        public static readonly ServiceOperation ReadInProgressQuests = new ServiceOperation("READ_IN_PROGRESS_QUESTS");
-        public static readonly ServiceOperation ReadNotStartedQuests = new ServiceOperation("READ_NOT_STARTED_QUESTS");
-        public static readonly ServiceOperation ReadQuestsWithStatus = new ServiceOperation("READ_QUESTS_WITH_STATUS");
-        public static readonly ServiceOperation ReadQuestsWithBasicPercentage = new ServiceOperation("READ_QUESTS_WITH_BASIC_PERCENTAGE");
-        public static readonly ServiceOperation ReadQuestsWithComplexPercentage = new ServiceOperation("READ_QUESTS_WITH_COMPLEX_PERCENTAGE");
-        public static readonly ServiceOperation ReadQuestsByCategory = new ServiceOperation("READ_QUESTS_BY_CATEGORY");
-        public static readonly ServiceOperation ResetMilestones = new ServiceOperation("RESET_MILESTONES");
+        public static readonly ServiceOperation ReadQuests = "READ_QUESTS";
+        public static readonly ServiceOperation ReadCompletedQuests = "READ_COMPLETED_QUESTS";
+        public static readonly ServiceOperation ReadInProgressQuests = "READ_IN_PROGRESS_QUESTS";
+        public static readonly ServiceOperation ReadNotStartedQuests = "READ_NOT_STARTED_QUESTS";
+        public static readonly ServiceOperation ReadQuestsWithStatus = "READ_QUESTS_WITH_STATUS";
+        public static readonly ServiceOperation ReadQuestsWithBasicPercentage = "READ_QUESTS_WITH_BASIC_PERCENTAGE";
+        public static readonly ServiceOperation ReadQuestsWithComplexPercentage = "READ_QUESTS_WITH_COMPLEX_PERCENTAGE";
+        public static readonly ServiceOperation ReadQuestsByCategory = "READ_QUESTS_BY_CATEGORY";
+        public static readonly ServiceOperation ResetMilestones = "RESET_MILESTONES";
 
-        public static readonly ServiceOperation ReadForCategory = new ServiceOperation("READ_FOR_CATEGORY");
+        public static readonly ServiceOperation ReadForCategory = "READ_FOR_CATEGORY";
 
-        public static readonly ServiceOperation ReadMilestones = new ServiceOperation("READ_MILESTONES");
-        public static readonly ServiceOperation ReadMilestonesByCategory = new ServiceOperation("READ_MILESTONES_BY_CATEGORY");
+        public static readonly ServiceOperation ReadMilestones = "READ_MILESTONES";
+        public static readonly ServiceOperation ReadMilestonesByCategory = "READ_MILESTONES_BY_CATEGORY";
 
-        public static readonly ServiceOperation ReadCompletedMilestones = new ServiceOperation("READ_COMPLETED_MILESTONES");
-        public static readonly ServiceOperation ReadInProgressMilestones = new ServiceOperation("READ_IN_PROGRESS_MILESTONES");
+        public static readonly ServiceOperation ReadCompletedMilestones = "READ_COMPLETED_MILESTONES";
+        public static readonly ServiceOperation ReadInProgressMilestones = "READ_IN_PROGRESS_MILESTONES";
 
-        public static readonly ServiceOperation Trigger = new ServiceOperation("TRIGGER");
-        public static readonly ServiceOperation TriggerMultiple = new ServiceOperation("TRIGGER_MULTIPLE");
+        public static readonly ServiceOperation Trigger = "TRIGGER";
+        public static readonly ServiceOperation TriggerMultiple = "TRIGGER_MULTIPLE";
 
-        public static readonly ServiceOperation Logout = new ServiceOperation("LOGOUT");
+        public static readonly ServiceOperation Logout = "LOGOUT";
 
-        public static readonly ServiceOperation StartMatch = new ServiceOperation("START_MATCH");
-        public static readonly ServiceOperation CancelMatch = new ServiceOperation("CANCEL_MATCH");
-        public static readonly ServiceOperation CompleteMatch = new ServiceOperation("COMPLETE_MATCH");
-        public static readonly ServiceOperation EnableMatchMaking = new ServiceOperation("ENABLE_FOR_MATCH");
-        public static readonly ServiceOperation DisableMatchMaking = new ServiceOperation("DISABLE_FOR_MATCH");
-        public static readonly ServiceOperation UpdateName = new ServiceOperation("UPDATE_NAME");
+        public static readonly ServiceOperation StartMatch = "START_MATCH";
+        public static readonly ServiceOperation CancelMatch = "CANCEL_MATCH";
+        public static readonly ServiceOperation CompleteMatch = "COMPLETE_MATCH";
+        public static readonly ServiceOperation EnableMatchMaking = "ENABLE_FOR_MATCH";
+        public static readonly ServiceOperation DisableMatchMaking = "DISABLE_FOR_MATCH";
+        public static readonly ServiceOperation UpdateName = "UPDATE_NAME";
 
-        public static readonly ServiceOperation StartStream = new ServiceOperation("START_STREAM");
-        public static readonly ServiceOperation ReadStream = new ServiceOperation("READ_STREAM");
-        public static readonly ServiceOperation EndStream = new ServiceOperation("END_STREAM");
-        public static readonly ServiceOperation DeleteStream = new ServiceOperation("DELETE_STREAM");
-        public static readonly ServiceOperation AddEvent = new ServiceOperation("ADD_EVENT");
-        public static readonly ServiceOperation ProtectStreamUntil = new ServiceOperation("PROTECT_STREAM_UNTIL");
+        public static readonly ServiceOperation StartStream = "START_STREAM";
+        public static readonly ServiceOperation ReadStream = "READ_STREAM";
+        public static readonly ServiceOperation EndStream = "END_STREAM";
+        public static readonly ServiceOperation DeleteStream = "DELETE_STREAM";
+        public static readonly ServiceOperation AddEvent = "ADD_EVENT";
+        public static readonly ServiceOperation ProtectStreamUntil = "PROTECT_STREAM_UNTIL";
 
-        public static readonly ServiceOperation GetStreamSummariesForInitiatingPlayer = new ServiceOperation("GET_STREAM_SUMMARIES_FOR_INITIATING_PLAYER");
-        public static readonly ServiceOperation GetStreamSummariesForTargetPlayer = new ServiceOperation("GET_STREAM_SUMMARIES_FOR_TARGET_PLAYER");
-        public static readonly ServiceOperation GetRecentStreamsForInitiatingPlayer = new ServiceOperation("GET_RECENT_STREAMS_FOR_INITIATING_PLAYER");
-        public static readonly ServiceOperation GetRecentStreamsForTargetPlayer = new ServiceOperation("GET_RECENT_STREAMS_FOR_TARGET_PLAYER");
+        public static readonly ServiceOperation GetStreamSummariesForInitiatingPlayer = "GET_STREAM_SUMMARIES_FOR_INITIATING_PLAYER";
+        public static readonly ServiceOperation GetStreamSummariesForTargetPlayer = "GET_STREAM_SUMMARIES_FOR_TARGET_PLAYER";
+        public static readonly ServiceOperation GetRecentStreamsForInitiatingPlayer = "GET_RECENT_STREAMS_FOR_INITIATING_PLAYER";
+        public static readonly ServiceOperation GetRecentStreamsForTargetPlayer = "GET_RECENT_STREAMS_FOR_TARGET_PLAYER";
 
-        public static readonly ServiceOperation GetUserInfo = new ServiceOperation("GET_USER_INFO");
-        public static readonly ServiceOperation InitializeTransaction = new ServiceOperation("INITIALIZE_TRANSACTION");
-        public static readonly ServiceOperation FinalizeTransaction = new ServiceOperation("FINALIZE_TRANSACTION");
+        public static readonly ServiceOperation GetUserInfo = "GET_USER_INFO";
+        public static readonly ServiceOperation InitializeTransaction = "INITIALIZE_TRANSACTION";
+        public static readonly ServiceOperation FinalizeTransaction = "FINALIZE_TRANSACTION";
 
-        public static readonly ServiceOperation CachePurchasePayloadContext = new ServiceOperation("CACHE_PURCHASE_PAYLOAD_CONTEXT");
-        public static readonly ServiceOperation VerifyPurchase = new ServiceOperation("VERIFY_PURCHASE");
-        public static readonly ServiceOperation StartSteamTransaction = new ServiceOperation("START_STEAM_TRANSACTION");
-        public static readonly ServiceOperation FinalizeSteamTransaction = new ServiceOperation("FINALIZE_STEAM_TRANSACTION");
-        public static readonly ServiceOperation VerifyMicrosoftReceipt = new ServiceOperation("VERIFY_MICROSOFT_RECEIPT");
-        public static readonly ServiceOperation EligiblePromotions = new ServiceOperation("ELIGIBLE_PROMOTIONS");
+        public static readonly ServiceOperation CachePurchasePayloadContext = "CACHE_PURCHASE_PAYLOAD_CONTEXT";
+        public static readonly ServiceOperation VerifyPurchase = "VERIFY_PURCHASE";
+        public static readonly ServiceOperation StartSteamTransaction = "START_STEAM_TRANSACTION";
+        public static readonly ServiceOperation FinalizeSteamTransaction = "FINALIZE_STEAM_TRANSACTION";
+        public static readonly ServiceOperation VerifyMicrosoftReceipt = "VERIFY_MICROSOFT_RECEIPT";
+        public static readonly ServiceOperation EligiblePromotions = "ELIGIBLE_PROMOTIONS";
 
-        public static readonly ServiceOperation ReadSharedEntitiesList = new ServiceOperation("READ_SHARED_ENTITIES_LIST");
-        public static readonly ServiceOperation GetList = new ServiceOperation("GET_LIST");
-        public static readonly ServiceOperation GetListByIndexedId = new ServiceOperation("GET_LIST_BY_INDEXED_ID");
-        public static readonly ServiceOperation GetListCount = new ServiceOperation("GET_LIST_COUNT");
-        public static readonly ServiceOperation GetPage = new ServiceOperation("GET_PAGE");
-        public static readonly ServiceOperation GetPageOffset = new ServiceOperation("GET_PAGE_BY_OFFSET");
-        public static readonly ServiceOperation IncrementGlobalEntityData = new ServiceOperation("INCREMENT_GLOBAL_ENTITY_DATA");
-        public static readonly ServiceOperation GetRandomEntitiesMatching = new ServiceOperation("GET_RANDOM_ENTITIES_MATCHING");
-        public static readonly ServiceOperation IncrementUserEntityData = new ServiceOperation("INCREMENT_USER_ENTITY_DATA");
-        public static readonly ServiceOperation IncrementSharedUserEntityData = new ServiceOperation("INCREMENT_SHARED_USER_ENTITY_DATA");
+        public static readonly ServiceOperation ReadSharedEntitiesList = "READ_SHARED_ENTITIES_LIST";
+        public static readonly ServiceOperation GetList = "GET_LIST";
+        public static readonly ServiceOperation GetListByIndexedId = "GET_LIST_BY_INDEXED_ID";
+        public static readonly ServiceOperation GetListCount = "GET_LIST_COUNT";
+        public static readonly ServiceOperation GetPage = "GET_PAGE";
+        public static readonly ServiceOperation GetPageOffset = "GET_PAGE_BY_OFFSET";
+        public static readonly ServiceOperation IncrementGlobalEntityData = "INCREMENT_GLOBAL_ENTITY_DATA";
+        public static readonly ServiceOperation GetRandomEntitiesMatching = "GET_RANDOM_ENTITIES_MATCHING";
+        public static readonly ServiceOperation IncrementUserEntityData = "INCREMENT_USER_ENTITY_DATA";
+        public static readonly ServiceOperation IncrementSharedUserEntityData = "INCREMENT_SHARED_USER_ENTITY_DATA";
 
-        public static readonly ServiceOperation UpdatePictureUrl = new ServiceOperation("UPDATE_PICTURE_URL");
-        public static readonly ServiceOperation UpdateContactEmail = new ServiceOperation("UPDATE_CONTACT_EMAIL");
-        public static readonly ServiceOperation UpdateLanguageCode = new ServiceOperation("UPDATE_LANGUAGE_CODE");
-        public static readonly ServiceOperation UpdateTimeZoneOffset = new ServiceOperation("UPDATE_TIMEZONE_OFFSET");
-        public static readonly ServiceOperation SetUserStatus = new ServiceOperation("SET_USER_STATUS");        
-        public static readonly ServiceOperation GetUserStatus = new ServiceOperation("GET_USER_STATUS");
-        public static readonly ServiceOperation ClearUserStatus = new ServiceOperation("CLEAR_USER_STATUS");
-        public static readonly ServiceOperation ExtendUserStatus = new ServiceOperation("EXTEND_USER_STATUS");
-        public static readonly ServiceOperation GetAttributes = new ServiceOperation("GET_ATTRIBUTES");
-        public static readonly ServiceOperation UpdateAttributes = new ServiceOperation("UPDATE_ATTRIBUTES");
-        public static readonly ServiceOperation RemoveAttributes = new ServiceOperation("REMOVE_ATTRIBUTES");
-        public static readonly ServiceOperation GetChildProfiles = new ServiceOperation("GET_CHILD_PROFILES");
-        public static readonly ServiceOperation GetIdentities = new ServiceOperation("GET_IDENTITIES");
-        public static readonly ServiceOperation GetExpiredIdentities = new ServiceOperation("GET_EXPIRED_IDENTITIES");
-        public static readonly ServiceOperation RefreshIdentity = new ServiceOperation("REFRESH_IDENTITY");
-        public static readonly ServiceOperation ChangeEmailIdentity = new ServiceOperation("CHANGE_EMAIL_IDENTITY");
+        public static readonly ServiceOperation UpdatePictureUrl = "UPDATE_PICTURE_URL";
+        public static readonly ServiceOperation UpdateContactEmail = "UPDATE_CONTACT_EMAIL";
+        public static readonly ServiceOperation UpdateLanguageCode = "UPDATE_LANGUAGE_CODE";
+        public static readonly ServiceOperation UpdateTimeZoneOffset = "UPDATE_TIMEZONE_OFFSET";
+        public static readonly ServiceOperation SetUserStatus = "SET_USER_STATUS";        
+        public static readonly ServiceOperation GetUserStatus = "GET_USER_STATUS";
+        public static readonly ServiceOperation ClearUserStatus = "CLEAR_USER_STATUS";
+        public static readonly ServiceOperation ExtendUserStatus = "EXTEND_USER_STATUS";
+        public static readonly ServiceOperation GetAttributes = "GET_ATTRIBUTES";
+        public static readonly ServiceOperation UpdateAttributes = "UPDATE_ATTRIBUTES";
+        public static readonly ServiceOperation RemoveAttributes = "REMOVE_ATTRIBUTES";
+        public static readonly ServiceOperation GetChildProfiles = "GET_CHILD_PROFILES";
+        public static readonly ServiceOperation GetIdentities = "GET_IDENTITIES";
+        public static readonly ServiceOperation GetExpiredIdentities = "GET_EXPIRED_IDENTITIES";
+        public static readonly ServiceOperation RefreshIdentity = "REFRESH_IDENTITY";
+        public static readonly ServiceOperation ChangeEmailIdentity = "CHANGE_EMAIL_IDENTITY";
 
-        public static readonly ServiceOperation FbConfirmPurchase = new ServiceOperation("FB_CONFIRM_PURCHASE");
-        public static readonly ServiceOperation GooglePlayConfirmPurchase = new ServiceOperation("CONFIRM_GOOGLEPLAY_PURCHASE");
+        public static readonly ServiceOperation FbConfirmPurchase = "FB_CONFIRM_PURCHASE";
+        public static readonly ServiceOperation GooglePlayConfirmPurchase = "CONFIRM_GOOGLEPLAY_PURCHASE";
 
-        public static readonly ServiceOperation ReadProperties = new ServiceOperation("READ_PROPERTIES");
-        public static readonly ServiceOperation ReadSelectedProperties = new ServiceOperation("READ_SELECTED_PROPERTIES");
-        public static readonly ServiceOperation ReadPropertiesInCategories = new ServiceOperation("READ_PROPERTIES_IN_CATEGORIES");
+        public static readonly ServiceOperation ReadProperties = "READ_PROPERTIES";
+        public static readonly ServiceOperation ReadSelectedProperties = "READ_SELECTED_PROPERTIES";
+        public static readonly ServiceOperation ReadPropertiesInCategories = "READ_PROPERTIES_IN_CATEGORIES";
 
-        public static readonly ServiceOperation GetUpdatedFiles = new ServiceOperation("GET_UPDATED_FILES");
-        public static readonly ServiceOperation GetFileList = new ServiceOperation("GET_FILE_LIST");
+        public static readonly ServiceOperation GetUpdatedFiles = "GET_UPDATED_FILES";
+        public static readonly ServiceOperation GetFileList = "GET_FILE_LIST";
 
-        public static readonly ServiceOperation ScheduleCloudScript = new ServiceOperation("SCHEDULE_CLOUD_SCRIPT");
-        public static readonly ServiceOperation GetScheduledCloudScripts = new ServiceOperation("GET_SCHEDULED_CLOUD_SCRIPTS");
-        public static readonly ServiceOperation GetRunningOrQueuedCloudScripts = new ServiceOperation("GET_RUNNING_OR_QUEUED_CLOUD_SCRIPTS");
-        public static readonly ServiceOperation RunParentScript = new ServiceOperation("RUN_PARENT_SCRIPT");
-        public static readonly ServiceOperation CancelScheduledScript = new ServiceOperation("CANCEL_SCHEDULED_SCRIPT");
-        public static readonly ServiceOperation RunPeerScript = new ServiceOperation("RUN_PEER_SCRIPT");
-        public static readonly ServiceOperation RunPeerScriptAsync = new ServiceOperation("RUN_PEER_SCRIPT_ASYNC");
+        public static readonly ServiceOperation ScheduleCloudScript = "SCHEDULE_CLOUD_SCRIPT";
+        public static readonly ServiceOperation GetScheduledCloudScripts = "GET_SCHEDULED_CLOUD_SCRIPTS";
+        public static readonly ServiceOperation GetRunningOrQueuedCloudScripts = "GET_RUNNING_OR_QUEUED_CLOUD_SCRIPTS";
+        public static readonly ServiceOperation RunParentScript = "RUN_PARENT_SCRIPT";
+        public static readonly ServiceOperation CancelScheduledScript = "CANCEL_SCHEDULED_SCRIPT";
+        public static readonly ServiceOperation RunPeerScript = "RUN_PEER_SCRIPT";
+        public static readonly ServiceOperation RunPeerScriptAsync = "RUN_PEER_SCRIPT_ASYNC";
 
         //RedemptionCode
-        public static readonly ServiceOperation GetRedeemedCodes = new ServiceOperation("GET_REDEEMED_CODES");
-        public static readonly ServiceOperation RedeemCode = new ServiceOperation("REDEEM_CODE");
+        public static readonly ServiceOperation GetRedeemedCodes = "GET_REDEEMED_CODES";
+        public static readonly ServiceOperation RedeemCode = "REDEEM_CODE";
 
         //DataStream
-        public static readonly ServiceOperation CustomPageEvent = new ServiceOperation("CUSTOM_PAGE_EVENT");
-        public static readonly ServiceOperation CustomScreenEvent = new ServiceOperation("CUSTOM_SCREEN_EVENT");
-        public static readonly ServiceOperation CustomTrackEvent = new ServiceOperation("CUSTOM_TRACK_EVENT");
-        public static readonly ServiceOperation SubmitCrashReport = new ServiceOperation("SEND_CRASH_REPORT");
+        public static readonly ServiceOperation CustomPageEvent = "CUSTOM_PAGE_EVENT";
+        public static readonly ServiceOperation CustomScreenEvent = "CUSTOM_SCREEN_EVENT";
+        public static readonly ServiceOperation CustomTrackEvent = "CUSTOM_TRACK_EVENT";
+        public static readonly ServiceOperation SubmitCrashReport = "SEND_CRASH_REPORT";
 
         //Profanity
-        public static readonly ServiceOperation ProfanityCheck = new ServiceOperation("PROFANITY_CHECK");
-        public static readonly ServiceOperation ProfanityReplaceText = new ServiceOperation("PROFANITY_REPLACE_TEXT");
-        public static readonly ServiceOperation ProfanityIdentifyBadWords = new ServiceOperation("PROFANITY_IDENTIFY_BAD_WORDS");
+        public static readonly ServiceOperation ProfanityCheck = "PROFANITY_CHECK";
+        public static readonly ServiceOperation ProfanityReplaceText = "PROFANITY_REPLACE_TEXT";
+        public static readonly ServiceOperation ProfanityIdentifyBadWords = "PROFANITY_IDENTIFY_BAD_WORDS";
 
         //file upload
-        public static readonly ServiceOperation PrepareUserUpload = new ServiceOperation("PREPARE_USER_UPLOAD");
-        public static readonly ServiceOperation ListUserFiles = new ServiceOperation("LIST_USER_FILES");
-        public static readonly ServiceOperation DeleteUserFile = new ServiceOperation("DELETE_USER_FILE");
-        public static readonly ServiceOperation DeleteUserFiles = new ServiceOperation("DELETE_USER_FILES");
-        public static readonly ServiceOperation GetCdnUrl = new ServiceOperation("GET_CDN_URL");
+        public static readonly ServiceOperation PrepareUserUpload = "PREPARE_USER_UPLOAD";
+        public static readonly ServiceOperation ListUserFiles = "LIST_USER_FILES";
+        public static readonly ServiceOperation DeleteUserFile = "DELETE_USER_FILE";
+        public static readonly ServiceOperation DeleteUserFiles = "DELETE_USER_FILES";
+        public static readonly ServiceOperation GetCdnUrl = "GET_CDN_URL";
 
         //group
-        public static readonly ServiceOperation AcceptGroupInvitation = new ServiceOperation("ACCEPT_GROUP_INVITATION");
-        public static readonly ServiceOperation AddGroupMember = new ServiceOperation("ADD_GROUP_MEMBER");
-        public static readonly ServiceOperation ApproveGroupJoinRequest = new ServiceOperation("APPROVE_GROUP_JOIN_REQUEST");
-        public static readonly ServiceOperation AutoJoinGroup = new ServiceOperation("AUTO_JOIN_GROUP");
-        public static readonly ServiceOperation AutoJoinGroupMulti = new ServiceOperation("AUTO_JOIN_GROUP_MULTI");
-        public static readonly ServiceOperation CancelGroupInvitation = new ServiceOperation("CANCEL_GROUP_INVITATION");
-        public static readonly ServiceOperation DeleteGroupJoinRequest = new ServiceOperation("DELETE_GROUP_JOIN_REQUEST");
-        public static readonly ServiceOperation CreateGroup = new ServiceOperation("CREATE_GROUP");
-        public static readonly ServiceOperation CreateGroupEntity = new ServiceOperation("CREATE_GROUP_ENTITY");
-        public static readonly ServiceOperation DeleteGroup = new ServiceOperation("DELETE_GROUP");
-        public static readonly ServiceOperation DeleteGroupEntity = new ServiceOperation("DELETE_GROUP_ENTITY");
-        public static readonly ServiceOperation DeleteGroupMemeber = new ServiceOperation("DELETE_MEMBER_FROM_GROUP");
-        public static readonly ServiceOperation GetMyGroups = new ServiceOperation("GET_MY_GROUPS");
-        public static readonly ServiceOperation IncrementGroupData = new ServiceOperation("INCREMENT_GROUP_DATA");
-        public static readonly ServiceOperation IncrementGroupEntityData = new ServiceOperation("INCREMENT_GROUP_ENTITY_DATA");
-        public static readonly ServiceOperation InviteGroupMember = new ServiceOperation("INVITE_GROUP_MEMBER");
-        public static readonly ServiceOperation JoinGroup = new ServiceOperation("JOIN_GROUP");
-        public static readonly ServiceOperation LeaveGroup = new ServiceOperation("LEAVE_GROUP");
-        public static readonly ServiceOperation ListGroupsPage = new ServiceOperation("LIST_GROUPS_PAGE");
-        public static readonly ServiceOperation ListGroupsPageByOffset = new ServiceOperation("LIST_GROUPS_PAGE_BY_OFFSET");
-        public static readonly ServiceOperation ListGroupsWithMember = new ServiceOperation("LIST_GROUPS_WITH_MEMBER");
-        public static readonly ServiceOperation ReadGroup = new ServiceOperation("READ_GROUP");
-        public static readonly ServiceOperation ReadGroupData = new ServiceOperation("READ_GROUP_DATA");
-        public static readonly ServiceOperation ReadGroupEntitiesPage = new ServiceOperation("READ_GROUP_ENTITIES_PAGE");
-        public static readonly ServiceOperation ReadGroupEntitiesPageByOffset = new ServiceOperation("READ_GROUP_ENTITIES_PAGE_BY_OFFSET");
-        public static readonly ServiceOperation ReadGroupEntity = new ServiceOperation("READ_GROUP_ENTITY");
-        public static readonly ServiceOperation ReadGroupMembers = new ServiceOperation("READ_GROUP_MEMBERS");
-        public static readonly ServiceOperation RejectGroupInvitation = new ServiceOperation("REJECT_GROUP_INVITATION");
-        public static readonly ServiceOperation RejectGroupJoinRequest = new ServiceOperation("REJECT_GROUP_JOIN_REQUEST");
-        public static readonly ServiceOperation RemoveGroupMember = new ServiceOperation("REMOVE_GROUP_MEMBER");
-        public static readonly ServiceOperation UpdateGroupData = new ServiceOperation("UPDATE_GROUP_DATA");
-        public static readonly ServiceOperation UpdateGroupEntity = new ServiceOperation("UPDATE_GROUP_ENTITY_DATA");
-        public static readonly ServiceOperation UpdateGroupMember = new ServiceOperation("UPDATE_GROUP_MEMBER");
-        public static readonly ServiceOperation UpdateGroupACL = new ServiceOperation("UPDATE_GROUP_ACL");
-        public static readonly ServiceOperation UpdateGroupEntityACL = new ServiceOperation("UPDATE_GROUP_ENTITY_ACL");
-        public static readonly ServiceOperation UpdateGroupName = new ServiceOperation("UPDATE_GROUP_NAME");
-        public static readonly ServiceOperation SetGroupOpen = new ServiceOperation("SET_GROUP_OPEN");
-        public static readonly ServiceOperation GetRandomGroupsMatching = new ServiceOperation("GET_RANDOM_GROUPS_MATCHING");
-        public static readonly ServiceOperation UpdateGroupSummaryData = new ServiceOperation("UPDATE_GROUP_SUMMARY_DATA");
+        public static readonly ServiceOperation AcceptGroupInvitation = "ACCEPT_GROUP_INVITATION";
+        public static readonly ServiceOperation AddGroupMember = "ADD_GROUP_MEMBER";
+        public static readonly ServiceOperation ApproveGroupJoinRequest = "APPROVE_GROUP_JOIN_REQUEST";
+        public static readonly ServiceOperation AutoJoinGroup = "AUTO_JOIN_GROUP";
+        public static readonly ServiceOperation AutoJoinGroupMulti = "AUTO_JOIN_GROUP_MULTI";
+        public static readonly ServiceOperation CancelGroupInvitation = "CANCEL_GROUP_INVITATION";
+        public static readonly ServiceOperation DeleteGroupJoinRequest = "DELETE_GROUP_JOIN_REQUEST";
+        public static readonly ServiceOperation CreateGroup = "CREATE_GROUP";
+        public static readonly ServiceOperation CreateGroupEntity = "CREATE_GROUP_ENTITY";
+        public static readonly ServiceOperation DeleteGroup = "DELETE_GROUP";
+        public static readonly ServiceOperation DeleteGroupEntity = "DELETE_GROUP_ENTITY";
+        public static readonly ServiceOperation DeleteGroupMemeber = "DELETE_MEMBER_FROM_GROUP";
+        public static readonly ServiceOperation GetMyGroups = "GET_MY_GROUPS";
+        public static readonly ServiceOperation IncrementGroupData = "INCREMENT_GROUP_DATA";
+        public static readonly ServiceOperation IncrementGroupEntityData = "INCREMENT_GROUP_ENTITY_DATA";
+        public static readonly ServiceOperation InviteGroupMember = "INVITE_GROUP_MEMBER";
+        public static readonly ServiceOperation JoinGroup = "JOIN_GROUP";
+        public static readonly ServiceOperation LeaveGroup = "LEAVE_GROUP";
+        public static readonly ServiceOperation ListGroupsPage = "LIST_GROUPS_PAGE";
+        public static readonly ServiceOperation ListGroupsPageByOffset = "LIST_GROUPS_PAGE_BY_OFFSET";
+        public static readonly ServiceOperation ListGroupsWithMember = "LIST_GROUPS_WITH_MEMBER";
+        public static readonly ServiceOperation ReadGroup = "READ_GROUP";
+        public static readonly ServiceOperation ReadGroupData = "READ_GROUP_DATA";
+        public static readonly ServiceOperation ReadGroupEntitiesPage = "READ_GROUP_ENTITIES_PAGE";
+        public static readonly ServiceOperation ReadGroupEntitiesPageByOffset = "READ_GROUP_ENTITIES_PAGE_BY_OFFSET";
+        public static readonly ServiceOperation ReadGroupEntity = "READ_GROUP_ENTITY";
+        public static readonly ServiceOperation ReadGroupMembers = "READ_GROUP_MEMBERS";
+        public static readonly ServiceOperation RejectGroupInvitation = "REJECT_GROUP_INVITATION";
+        public static readonly ServiceOperation RejectGroupJoinRequest = "REJECT_GROUP_JOIN_REQUEST";
+        public static readonly ServiceOperation RemoveGroupMember = "REMOVE_GROUP_MEMBER";
+        public static readonly ServiceOperation UpdateGroupData = "UPDATE_GROUP_DATA";
+        public static readonly ServiceOperation UpdateGroupEntity = "UPDATE_GROUP_ENTITY_DATA";
+        public static readonly ServiceOperation UpdateGroupMember = "UPDATE_GROUP_MEMBER";
+        public static readonly ServiceOperation UpdateGroupACL = "UPDATE_GROUP_ACL";
+        public static readonly ServiceOperation UpdateGroupEntityACL = "UPDATE_GROUP_ENTITY_ACL";
+        public static readonly ServiceOperation UpdateGroupName = "UPDATE_GROUP_NAME";
+        public static readonly ServiceOperation SetGroupOpen = "SET_GROUP_OPEN";
+        public static readonly ServiceOperation GetRandomGroupsMatching = "GET_RANDOM_GROUPS_MATCHING";
+        public static readonly ServiceOperation UpdateGroupSummaryData = "UPDATE_GROUP_SUMMARY_DATA";
 
         //mail
-        public static readonly ServiceOperation SendBasicEmail = new ServiceOperation("SEND_BASIC_EMAIL");
-        public static readonly ServiceOperation SendAdvancedEmail = new ServiceOperation("SEND_ADVANCED_EMAIL");
-        public static readonly ServiceOperation SendAdvancedEmailByAddress = new ServiceOperation("SEND_ADVANCED_EMAIL_BY_ADDRESS");
-        public static readonly ServiceOperation SendAdvancedEmailByAddresses = new ServiceOperation("SEND_ADVANCED_EMAIL_BY_ADDRESSES");
+        public static readonly ServiceOperation SendBasicEmail = "SEND_BASIC_EMAIL";
+        public static readonly ServiceOperation SendAdvancedEmail = "SEND_ADVANCED_EMAIL";
+        public static readonly ServiceOperation SendAdvancedEmailByAddress = "SEND_ADVANCED_EMAIL_BY_ADDRESS";
+        public static readonly ServiceOperation SendAdvancedEmailByAddresses = "SEND_ADVANCED_EMAIL_BY_ADDRESSES";
 
         //peer
-        public static readonly ServiceOperation AttachPeerProfile = new ServiceOperation("ATTACH_PEER_PROFILE");
-        public static readonly ServiceOperation DetachPeer = new ServiceOperation("DETACH_PEER");
-        public static readonly ServiceOperation GetPeerProfiles = new ServiceOperation("GET_PEER_PROFILES");
+        public static readonly ServiceOperation AttachPeerProfile = "ATTACH_PEER_PROFILE";
+        public static readonly ServiceOperation DetachPeer = "DETACH_PEER";
+        public static readonly ServiceOperation GetPeerProfiles = "GET_PEER_PROFILES";
 
         //presence
-        public static readonly ServiceOperation ForcePush = new ServiceOperation("FORCE_PUSH");
-        public static readonly ServiceOperation GetPresenceOfFriends = new ServiceOperation("GET_PRESENCE_OF_FRIENDS");
-        public static readonly ServiceOperation GetPresenceOfGroup = new ServiceOperation("GET_PRESENCE_OF_GROUP");
-        public static readonly ServiceOperation GetPresenceOfUsers = new ServiceOperation("GET_PRESENCE_OF_USERS");
-        public static readonly ServiceOperation RegisterListenersForFriends = new ServiceOperation("REGISTER_LISTENERS_FOR_FRIENDS");
-        public static readonly ServiceOperation RegisterListenersForGroup = new ServiceOperation("REGISTER_LISTENERS_FOR_GROUP");
-        public static readonly ServiceOperation RegisterListenersForProfiles = new ServiceOperation("REGISTER_LISTENERS_FOR_PROFILES");
-        public static readonly ServiceOperation SetVisibility = new ServiceOperation("SET_VISIBILITY");
-        public static readonly ServiceOperation StopListening = new ServiceOperation("STOP_LISTENING");
-        public static readonly ServiceOperation UpdateActivity = new ServiceOperation("UPDATE_ACTIVITY");
+        public static readonly ServiceOperation ForcePush = "FORCE_PUSH";
+        public static readonly ServiceOperation GetPresenceOfFriends = "GET_PRESENCE_OF_FRIENDS";
+        public static readonly ServiceOperation GetPresenceOfGroup = "GET_PRESENCE_OF_GROUP";
+        public static readonly ServiceOperation GetPresenceOfUsers = "GET_PRESENCE_OF_USERS";
+        public static readonly ServiceOperation RegisterListenersForFriends = "REGISTER_LISTENERS_FOR_FRIENDS";
+        public static readonly ServiceOperation RegisterListenersForGroup = "REGISTER_LISTENERS_FOR_GROUP";
+        public static readonly ServiceOperation RegisterListenersForProfiles = "REGISTER_LISTENERS_FOR_PROFILES";
+        public static readonly ServiceOperation SetVisibility = "SET_VISIBILITY";
+        public static readonly ServiceOperation StopListening = "STOP_LISTENING";
+        public static readonly ServiceOperation UpdateActivity = "UPDATE_ACTIVITY";
 
         //tournament
-        public static readonly ServiceOperation GetTournamentStatus = new ServiceOperation("GET_TOURNAMENT_STATUS");
-        public static readonly ServiceOperation GetDivisionInfo = new ServiceOperation("GET_DIVISION_INFO");
-        public static readonly ServiceOperation GetMyDivisions = new ServiceOperation("GET_MY_DIVISIONS");
-        public static readonly ServiceOperation JoinDivision= new ServiceOperation("JOIN_DIVISION");
-        public static readonly ServiceOperation JoinTournament = new ServiceOperation("JOIN_TOURNAMENT");
-        public static readonly ServiceOperation LeaveDivisionInstance = new ServiceOperation("LEAVE_DIVISION_INSTANCE");
-        public static readonly ServiceOperation LeaveTournament = new ServiceOperation("LEAVE_TOURNAMENT");
-        public static readonly ServiceOperation PostTournamentScore = new ServiceOperation("POST_TOURNAMENT_SCORE");
-        public static readonly ServiceOperation PostTournamentScoreWithResults = new ServiceOperation("POST_TOURNAMENT_SCORE_WITH_RESULTS");
-        public static readonly ServiceOperation ViewCurrentReward = new ServiceOperation("VIEW_CURRENT_REWARD");
-        public static readonly ServiceOperation ViewReward = new ServiceOperation("VIEW_REWARD");
-        public static readonly ServiceOperation ClaimTournamentReward = new ServiceOperation("CLAIM_TOURNAMENT_REWARD");
+        public static readonly ServiceOperation GetTournamentStatus = "GET_TOURNAMENT_STATUS";
+        public static readonly ServiceOperation GetDivisionInfo = "GET_DIVISION_INFO";
+        public static readonly ServiceOperation GetMyDivisions = "GET_MY_DIVISIONS";
+        public static readonly ServiceOperation JoinDivision= "JOIN_DIVISION";
+        public static readonly ServiceOperation JoinTournament = "JOIN_TOURNAMENT";
+        public static readonly ServiceOperation LeaveDivisionInstance = "LEAVE_DIVISION_INSTANCE";
+        public static readonly ServiceOperation LeaveTournament = "LEAVE_TOURNAMENT";
+        public static readonly ServiceOperation PostTournamentScore = "POST_TOURNAMENT_SCORE";
+        public static readonly ServiceOperation PostTournamentScoreWithResults = "POST_TOURNAMENT_SCORE_WITH_RESULTS";
+        public static readonly ServiceOperation ViewCurrentReward = "VIEW_CURRENT_REWARD";
+        public static readonly ServiceOperation ViewReward = "VIEW_REWARD";
+        public static readonly ServiceOperation ClaimTournamentReward = "CLAIM_TOURNAMENT_REWARD";
 
         // rtt
-        public static readonly ServiceOperation RequestClientConnection = new ServiceOperation("REQUEST_CLIENT_CONNECTION");
+        public static readonly ServiceOperation RequestClientConnection = "REQUEST_CLIENT_CONNECTION";
 
         // chat
-        public static readonly ServiceOperation ChannelConnect = new ServiceOperation("CHANNEL_CONNECT");
-        public static readonly ServiceOperation ChannelDisconnect = new ServiceOperation("CHANNEL_DISCONNECT");
-        public static readonly ServiceOperation DeleteChatMessage = new ServiceOperation("DELETE_CHAT_MESSAGE");
-        public static readonly ServiceOperation GetChannelId = new ServiceOperation("GET_CHANNEL_ID");
-        public static readonly ServiceOperation GetChannelInfo = new ServiceOperation("GET_CHANNEL_INFO");
-        public static readonly ServiceOperation GetChatMessage = new ServiceOperation("GET_CHAT_MESSAGE");
-        public static readonly ServiceOperation GetRecentChatMessages = new ServiceOperation("GET_RECENT_CHAT_MESSAGES");
-        public static readonly ServiceOperation GetSubscribedChannels = new ServiceOperation("GET_SUBSCRIBED_CHANNELS");
-        public static readonly ServiceOperation PostChatMessage = new ServiceOperation("POST_CHAT_MESSAGE");
-        public static readonly ServiceOperation PostChatMessageSimple = new ServiceOperation("POST_CHAT_MESSAGE_SIMPLE");
-        public static readonly ServiceOperation UpdateChatMessage = new ServiceOperation("UPDATE_CHAT_MESSAGE");
+        public static readonly ServiceOperation ChannelConnect = "CHANNEL_CONNECT";
+        public static readonly ServiceOperation ChannelDisconnect = "CHANNEL_DISCONNECT";
+        public static readonly ServiceOperation DeleteChatMessage = "DELETE_CHAT_MESSAGE";
+        public static readonly ServiceOperation GetChannelId = "GET_CHANNEL_ID";
+        public static readonly ServiceOperation GetChannelInfo = "GET_CHANNEL_INFO";
+        public static readonly ServiceOperation GetChatMessage = "GET_CHAT_MESSAGE";
+        public static readonly ServiceOperation GetRecentChatMessages = "GET_RECENT_CHAT_MESSAGES";
+        public static readonly ServiceOperation GetSubscribedChannels = "GET_SUBSCRIBED_CHANNELS";
+        public static readonly ServiceOperation PostChatMessage = "POST_CHAT_MESSAGE";
+        public static readonly ServiceOperation PostChatMessageSimple = "POST_CHAT_MESSAGE_SIMPLE";
+        public static readonly ServiceOperation UpdateChatMessage = "UPDATE_CHAT_MESSAGE";
 
         // messaging 
-        public static readonly ServiceOperation DeleteMessages = new ServiceOperation("DELETE_MESSAGES");
-        public static readonly ServiceOperation GetMessageBoxes = new ServiceOperation("GET_MESSAGE_BOXES");
-        public static readonly ServiceOperation GetMessageCounts = new ServiceOperation("GET_MESSAGE_COUNTS");
-        public static readonly ServiceOperation GetMessages = new ServiceOperation("GET_MESSAGES");
-        public static readonly ServiceOperation GetMessagesPage = new ServiceOperation("GET_MESSAGES_PAGE");
-        public static readonly ServiceOperation GetMessagesPageOffset = new ServiceOperation("GET_MESSAGES_PAGE_OFFSET");
-        public static readonly ServiceOperation MarkMessagesRead = new ServiceOperation("MARK_MESSAGES_READ");
-        public static readonly ServiceOperation SendMessage = new ServiceOperation("SEND_MESSAGE");
-        public static readonly ServiceOperation SendMessageSimple = new ServiceOperation("SEND_MESSAGE_SIMPLE");
+        public static readonly ServiceOperation DeleteMessages = "DELETE_MESSAGES";
+        public static readonly ServiceOperation GetMessageBoxes = "GET_MESSAGE_BOXES";
+        public static readonly ServiceOperation GetMessageCounts = "GET_MESSAGE_COUNTS";
+        public static readonly ServiceOperation GetMessages = "GET_MESSAGES";
+        public static readonly ServiceOperation GetMessagesPage = "GET_MESSAGES_PAGE";
+        public static readonly ServiceOperation GetMessagesPageOffset = "GET_MESSAGES_PAGE_OFFSET";
+        public static readonly ServiceOperation MarkMessagesRead = "MARK_MESSAGES_READ";
+        public static readonly ServiceOperation SendMessage = "SEND_MESSAGE";
+        public static readonly ServiceOperation SendMessageSimple = "SEND_MESSAGE_SIMPLE";
 
         // lobby
-        public static readonly ServiceOperation FindLobby = new ServiceOperation("FIND_LOBBY");
-        public static readonly ServiceOperation FindLobbyWithPingData = new ServiceOperation("FIND_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation CreateLobby = new ServiceOperation("CREATE_LOBBY");
-        public static readonly ServiceOperation CreateLobbyWithPingData = new ServiceOperation("CREATE_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation FindOrCreateLobby = new ServiceOperation("FIND_OR_CREATE_LOBBY");
-        public static readonly ServiceOperation FindOrCreateLobbyWithPingData = new ServiceOperation("FIND_OR_CREATE_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation GetLobbyData = new ServiceOperation("GET_LOBBY_DATA");
-        public static readonly ServiceOperation UpdateReady = new ServiceOperation("UPDATE_READY");
-        public static readonly ServiceOperation UpdateSettings = new ServiceOperation("UPDATE_SETTINGS");
-        public static readonly ServiceOperation SwitchTeam = new ServiceOperation("SWITCH_TEAM");
-        public static readonly ServiceOperation SendSignal = new ServiceOperation("SEND_SIGNAL");
-        public static readonly ServiceOperation JoinLobby = new ServiceOperation("JOIN_LOBBY");
-        public static readonly ServiceOperation JoinLobbyWithPingData = new ServiceOperation("JOIN_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation LeaveLobby = new ServiceOperation("LEAVE_LOBBY");
-        public static readonly ServiceOperation RemoveMember = new ServiceOperation("REMOVE_MEMBER");
-        public static readonly ServiceOperation CancelFindRequest = new ServiceOperation("CANCEL_FIND_REQUEST");
-        public static readonly ServiceOperation GetRegionsForLobbies = new ServiceOperation("GET_REGIONS_FOR_LOBBIES");
-        public static readonly ServiceOperation GetLobbyInstances = new ServiceOperation("GET_LOBBY_INSTANCES");
-        public static readonly ServiceOperation GetLobbyInstancesWithPingData = new ServiceOperation("GET_LOBBY_INSTANCES_WITH_PING_DATA");
+        public static readonly ServiceOperation FindLobby = "FIND_LOBBY";
+        public static readonly ServiceOperation FindLobbyWithPingData = "FIND_LOBBY_WITH_PING_DATA";
+        public static readonly ServiceOperation CreateLobby = "CREATE_LOBBY";
+        public static readonly ServiceOperation CreateLobbyWithPingData = "CREATE_LOBBY_WITH_PING_DATA";
+        public static readonly ServiceOperation FindOrCreateLobby = "FIND_OR_CREATE_LOBBY";
+        public static readonly ServiceOperation FindOrCreateLobbyWithPingData = "FIND_OR_CREATE_LOBBY_WITH_PING_DATA";
+        public static readonly ServiceOperation GetLobbyData = "GET_LOBBY_DATA";
+        public static readonly ServiceOperation UpdateReady = "UPDATE_READY";
+        public static readonly ServiceOperation UpdateSettings = "UPDATE_SETTINGS";
+        public static readonly ServiceOperation SwitchTeam = "SWITCH_TEAM";
+        public static readonly ServiceOperation SendSignal = "SEND_SIGNAL";
+        public static readonly ServiceOperation JoinLobby = "JOIN_LOBBY";
+        public static readonly ServiceOperation JoinLobbyWithPingData = "JOIN_LOBBY_WITH_PING_DATA";
+        public static readonly ServiceOperation LeaveLobby = "LEAVE_LOBBY";
+        public static readonly ServiceOperation RemoveMember = "REMOVE_MEMBER";
+        public static readonly ServiceOperation CancelFindRequest = "CANCEL_FIND_REQUEST";
+        public static readonly ServiceOperation GetRegionsForLobbies = "GET_REGIONS_FOR_LOBBIES";
+        public static readonly ServiceOperation GetLobbyInstances = "GET_LOBBY_INSTANCES";
+        public static readonly ServiceOperation GetLobbyInstancesWithPingData = "GET_LOBBY_INSTANCES_WITH_PING_DATA";
 
         
         //ItemCatalog
-        public static readonly ServiceOperation GetCatalogItemDefinition = new ServiceOperation("GET_CATALOG_ITEM_DEFINITION");
-        public static readonly ServiceOperation GetCatalogItemsPage = new ServiceOperation("GET_CATALOG_ITEMS_PAGE");
-        public static readonly ServiceOperation GetCatalogItemsPageOffset = new ServiceOperation("GET_CATALOG_ITEMS_PAGE_OFFSET");
+        public static readonly ServiceOperation GetCatalogItemDefinition = "GET_CATALOG_ITEM_DEFINITION";
+        public static readonly ServiceOperation GetCatalogItemsPage = "GET_CATALOG_ITEMS_PAGE";
+        public static readonly ServiceOperation GetCatalogItemsPageOffset = "GET_CATALOG_ITEMS_PAGE_OFFSET";
 
         //CustomEntity
 
-        public static readonly ServiceOperation DeleteEntities = new ServiceOperation("DELETE_ENTITIES");
-        public static readonly ServiceOperation CreateCustomEntity = new ServiceOperation("CREATE_ENTITY");
-        public static readonly ServiceOperation GetCustomEntityPage = new ServiceOperation("GET_PAGE");
-        public static readonly ServiceOperation GetCustomEntityPageOffset = new ServiceOperation("GET_ENTITY_PAGE_OFFSET");
-        public static readonly ServiceOperation GetEntityPage = new ServiceOperation("GET_ENTITY_PAGE");
-        public static readonly ServiceOperation ReadCustomEntity = new ServiceOperation("READ_ENTITY");
-        public static readonly ServiceOperation IncrementData = new ServiceOperation("INCREMENT_DATA");
-        public static readonly ServiceOperation IncrementSingletonData = new ServiceOperation("INCREMENT_SINGLETON_DATA");
-        public static readonly ServiceOperation UpdateCustomEntity = new ServiceOperation("UPDATE_ENTITY");
-        public static readonly ServiceOperation UpdateCustomEntityFields = new ServiceOperation("UPDATE_ENTITY_FIELDS");
-        public static readonly ServiceOperation UpdateCustomEntityFieldsShards = new ServiceOperation("UPDATE_ENTITY_FIELDS_SHARDED");
-        public static readonly ServiceOperation DeleteCustomEntity = new ServiceOperation("DELETE_ENTITY");
-        public static readonly ServiceOperation GetCount = new ServiceOperation("GET_COUNT");
-        public static readonly ServiceOperation UpdateSingletonFields = new ServiceOperation("UPDATE_SINGLETON_FIELDS");
+        public static readonly ServiceOperation DeleteEntities = "DELETE_ENTITIES";
+        public static readonly ServiceOperation CreateCustomEntity = "CREATE_ENTITY";
+        public static readonly ServiceOperation GetCustomEntityPage = "GET_PAGE";
+        public static readonly ServiceOperation GetCustomEntityPageOffset = "GET_ENTITY_PAGE_OFFSET";
+        public static readonly ServiceOperation GetEntityPage = "GET_ENTITY_PAGE";
+        public static readonly ServiceOperation ReadCustomEntity = "READ_ENTITY";
+        public static readonly ServiceOperation IncrementData = "INCREMENT_DATA";
+        public static readonly ServiceOperation IncrementSingletonData = "INCREMENT_SINGLETON_DATA";
+        public static readonly ServiceOperation UpdateCustomEntity = "UPDATE_ENTITY";
+        public static readonly ServiceOperation UpdateCustomEntityFields = "UPDATE_ENTITY_FIELDS";
+        public static readonly ServiceOperation UpdateCustomEntityFieldsShards = "UPDATE_ENTITY_FIELDS_SHARDED";
+        public static readonly ServiceOperation DeleteCustomEntity = "DELETE_ENTITY";
+        public static readonly ServiceOperation GetCount = "GET_COUNT";
+        public static readonly ServiceOperation UpdateSingletonFields = "UPDATE_SINGLETON_FIELDS";
 
         //UserItemsService
 
-        public static readonly ServiceOperation AwardUserItem = new ServiceOperation("AWARD_USER_ITEM");
-        public static readonly ServiceOperation DropUserItem = new ServiceOperation("DROP_USER_ITEM");
-        public static readonly ServiceOperation GetUserItemsPage = new ServiceOperation("GET_USER_ITEMS_PAGE");
-        public static readonly ServiceOperation GetUserItemsPageOffset = new ServiceOperation("GET_USER_ITEMS_PAGE_OFFSET");
-        public static readonly ServiceOperation GetUserItem = new ServiceOperation("GET_USER_ITEM");
-        public static readonly ServiceOperation GiveUserItemTo = new ServiceOperation("GIVE_USER_ITEM_TO");
-        public static readonly ServiceOperation PurchaseUserItem = new ServiceOperation("PURCHASE_USER_ITEM");
-        public static readonly ServiceOperation ReceiveUserItemFrom = new ServiceOperation("RECEIVE_USER_ITEM_FROM");
-        public static readonly ServiceOperation SellUserItem = new ServiceOperation("SELL_USER_ITEM");
-        public static readonly ServiceOperation UpdateUserItemData = new ServiceOperation("UPDATE_USER_ITEM_DATA");
-        public static readonly ServiceOperation UseUserItem = new ServiceOperation("USE_USER_ITEM");
-        public static readonly ServiceOperation PublishUserItemToBlockchain = new ServiceOperation("PUBLISH_USER_ITEM_TO_BLOCKCHAIN");
-        public static readonly ServiceOperation RefreshBlockchainUserItems = new ServiceOperation("REFRESH_BLOCKCHAIN_USER_ITEMS");
-        public static readonly ServiceOperation RemoveUserItemFromBlockchain = new ServiceOperation("REMOVE_USER_ITEM_FROM_BLOCKCHAIN");
+        public static readonly ServiceOperation AwardUserItem = "AWARD_USER_ITEM";
+        public static readonly ServiceOperation DropUserItem = "DROP_USER_ITEM";
+        public static readonly ServiceOperation GetUserItemsPage = "GET_USER_ITEMS_PAGE";
+        public static readonly ServiceOperation GetUserItemsPageOffset = "GET_USER_ITEMS_PAGE_OFFSET";
+        public static readonly ServiceOperation GetUserItem = "GET_USER_ITEM";
+        public static readonly ServiceOperation GiveUserItemTo = "GIVE_USER_ITEM_TO";
+        public static readonly ServiceOperation PurchaseUserItem = "PURCHASE_USER_ITEM";
+        public static readonly ServiceOperation ReceiveUserItemFrom = "RECEIVE_USER_ITEM_FROM";
+        public static readonly ServiceOperation SellUserItem = "SELL_USER_ITEM";
+        public static readonly ServiceOperation UpdateUserItemData = "UPDATE_USER_ITEM_DATA";
+        public static readonly ServiceOperation UseUserItem = "USE_USER_ITEM";
+        public static readonly ServiceOperation PublishUserItemToBlockchain = "PUBLISH_USER_ITEM_TO_BLOCKCHAIN";
+        public static readonly ServiceOperation RefreshBlockchainUserItems = "REFRESH_BLOCKCHAIN_USER_ITEMS";
+        public static readonly ServiceOperation RemoveUserItemFromBlockchain = "REMOVE_USER_ITEM_FROM_BLOCKCHAIN";
 
         //Group File Services
-        public static readonly ServiceOperation CheckFilenameExists = new ServiceOperation("CHECK_FILENAME_EXISTS");
-        public static readonly ServiceOperation CheckFullpathFilenameExists = new ServiceOperation("CHECK_FULLPATH_FILENAME_EXISTS");
-        public static readonly ServiceOperation CopyFile = new ServiceOperation("COPY_FILE");
-        public static readonly ServiceOperation DeleteFile = new ServiceOperation("DELETE_FILE");
-        public static readonly ServiceOperation MoveFile = new ServiceOperation("MOVE_FILE");
-        public static readonly ServiceOperation MoveUserToGroupFile = new ServiceOperation("MOVE_USER_TO_GROUP_FILE");
-        public static readonly ServiceOperation UpdateFileInfo = new ServiceOperation("UPDATE_FILE_INFO");
+        public static readonly ServiceOperation CheckFilenameExists = "CHECK_FILENAME_EXISTS";
+        public static readonly ServiceOperation CheckFullpathFilenameExists = "CHECK_FULLPATH_FILENAME_EXISTS";
+        public static readonly ServiceOperation CopyFile = "COPY_FILE";
+        public static readonly ServiceOperation DeleteFile = "DELETE_FILE";
+        public static readonly ServiceOperation MoveFile = "MOVE_FILE";
+        public static readonly ServiceOperation MoveUserToGroupFile = "MOVE_USER_TO_GROUP_FILE";
+        public static readonly ServiceOperation UpdateFileInfo = "UPDATE_FILE_INFO";
 
-
-
-
-
-
+        #endregion
 
         private ServiceOperation(string value)
         {
             Value = value;
         }
 
-        public string Value
+        public string Value { get; private set; }
+
+        #region Overrides and Operators
+
+        public override bool Equals(object obj)
         {
-            get;
-            private set;
+            if (obj is not ServiceOperation c)
+                return false;
+
+            return Equals(c);
         }
+
+        public bool Equals(ServiceOperation other)
+        {
+            if (GetType() != other.GetType())
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Value == other.Value;
+        }
+
+        public int CompareTo(ServiceOperation other)
+        {
+            if (GetType() != other.GetType())
+                return 1;
+
+            if (ReferenceEquals(this, other))
+                return 0;
+
+            return Value.CompareTo(other.Value);
+        }
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override string ToString() => Value;
+
+        public static implicit operator string(ServiceOperation v) => v.Value;
+
+        public static implicit operator ServiceOperation(string v) => new(v);
+
+        public static bool operator ==(ServiceOperation v1, ServiceOperation v2) => v1.Equals(v2);
+
+        public static bool operator !=(ServiceOperation v1, ServiceOperation v2) => !(v1 == v2);
+
+        public static bool operator >(ServiceOperation v1, ServiceOperation v2) => v1.CompareTo(v2) == 1;
+
+        public static bool operator <(ServiceOperation v1, ServiceOperation v2) => v1.CompareTo(v2) == -1;
+
+        public static bool operator >=(ServiceOperation v1, ServiceOperation v2) => v1.CompareTo(v2) >= 0;
+
+        public static bool operator <=(ServiceOperation v1, ServiceOperation v2) => v1.CompareTo(v2) <= 0;
+
+        #endregion
     }
 }


### PR DESCRIPTION
Changing the newly exposed `ServiceName`, `ServiceOperation`, and `OperationParams ` to make use of C# features.

First, they've been changed to structs instead of classes. These parameters are not meant to be inherited (plus ServiceName was sealed). Structs are more appropriate for these parameters with the way they're used since they're just holding a single string.

I also added `IEquatable` and `IComparable` to these which helps for data storage and sorting. It's not a big deal but it's just good C# code to do so. 🙂 I made use to add the proper interface calls for them and as well as overriding `ToString()` and `GetHashCode()` to explicitly make use of `Value`.

Finally I added some implicit operators to be able to convert these to `string` and vice-versa without the use of `Value`; `Value` can still be used (and it is throughout the scripts; I hadn't removed those from the API calls). Again it's not necessary but it makes the code cleaner to read and again is good C# code I think.

Ran a test on my end and all of the changes should not affect brainCloud calls.