### PR TITLE
New Tournament API + Unit Tests

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudTournament.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/BrainCloudTournament.cs
@@ -505,5 +505,262 @@ namespace BrainCloud
             ServerCall sc = new ServerCall(ServiceName.Tournament, ServiceOperation.ViewReward, data, callback);
             _client.SendRequest(sc);
         }
+        
+        /// <summary>
+        /// Post the users score to the leaderboard and returns the results
+        /// </summary>
+        /// <remarks>
+        /// Service Name - tournament
+        /// Service Operation - POST_GROUP_TOURNAMENT_SCORE_WITH_RESULTS
+        /// </remarks>
+        /// <param name="leaderboardId">The leaderboard for the tournament</param>
+        /// <param name="score">The score to post</param>
+        /// <param name="jsonData">Optional data attached to the leaderboard entry</param>
+        /// <param name="roundStartTimeUTC">Uses UTC time in milliseconds since epoch</param>
+        /// <param name="sort">Sort key Sort order of page.</param>
+        /// <param name="beforeCount">The count of number of players before the current player to include.</param>
+        /// <param name="afterCount">The count of number of players after the current player to include.</param>
+        /// <param name="initialScore">The initial score for players first joining a tournament.Usually 0, unless leaderboard is LOW_VALUE</param>
+        /// <param name="success">The success callback.</param>
+        /// <param name="failure">The failure callback.</param>
+        /// <param name="cbObject">The user object sent to the callback.</param>
+        public void PostGroupTournamentScoreWithResults(
+             string leaderboardId,
+             string groupId,
+             long score,
+             string jsonData,
+             ulong roundStartTimeUTC,
+             BrainCloudSocialLeaderboard.SortOrder sort,
+             int beforeCount,
+             int afterCount,
+             long initialScore,
+             SuccessCallback success = null,
+             FailureCallback failure = null,
+             object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.SocialLeaderboardServiceLeaderboardId.Value] = leaderboardId;
+            data[OperationParam.GroupId.Value] = groupId;
+            data[OperationParam.Score.Value] = score;
+            data[OperationParam.RoundStartedEpoch.Value] = roundStartTimeUTC;
+            data[OperationParam.InitialScore.Value] = initialScore;
+            data[OperationParam.SocialLeaderboardServiceSort.Value] = sort.ToString();
+            data[OperationParam.SocialLeaderboardServiceBeforeCount.Value] = beforeCount;
+            data[OperationParam.SocialLeaderboardServiceAfterCount.Value] = afterCount;
+            
+            if (Util.IsOptionalParameterValid(jsonData))
+            {
+                Dictionary<string, object> scoreData = JsonReader.Deserialize<Dictionary<string, object>>(jsonData);
+                data[OperationParam.Data.Value] = scoreData;
+            }
+
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.PostGroupTournamentScoreWithResults, data, callback));
+        }
+        
+        /// <summary>
+        /// Get the status of a group division
+        /// </summary>
+        /// <remarks>
+        /// Service Name - tournament
+        /// Service Operation - GET_GROUP_DIVISION_INFO
+        /// </remarks>
+        /// <param name="divSetId">The id for the division</param>
+        /// <param name="groupId">The group id</param>
+        /// <param name="success">The success callback.</param>
+        /// <param name="failure">The failure callback.</param>
+        /// <param name="cbObject">The user object sent to the callback.</param>
+        public void GetGroupDivisionInfo(
+            string divSetId, 
+            string groupId, 
+            SuccessCallback success = null,
+            FailureCallback failure = null,
+            object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.DivSetId.Value] = divSetId;
+            data[OperationParam.GroupId.Value] = groupId;
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.GetGroupDivisionInfo, data, callback));
+        }
+        
+         /// <summary>
+         /// Returns list of groups recently active divisions
+         /// </summary>
+         /// <remarks>
+         /// Service Name - tournament
+         /// Service Operation - GET_GROUP_DIVISIONS
+         /// </remarks>
+         ///
+         /// <param name="groupId">The group id</param>
+         /// <param name="success">The success callback.</param>
+         /// <param name="failure">The failure callback.</param>
+         /// <param name="cbObject">The user object sent to the callback.</param>
+         public void GetGroupDivisions(string groupId, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.GroupId.Value] = groupId;
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.GetGroupDivisions, data, callback));
+        }
+
+        /// <summary>
+        /// Get group tournament status associated with a leaderboard
+        /// </summary>
+        /// <remarks>
+        /// Service Name - tournament
+        /// Service Operation - GET_GROUP_TOURNAMENT_STATUS
+        /// </remarks>
+        /// <param name="leaderboardId">The leaderboard associated with the tournament.</param>
+        /// <param name="groupId">The unique identifier of the group.</param>
+        /// <param name="versionId">The version of the tournament. Use -1 for the latest version.</param>
+        /// <param name="success">The success callback.</param>
+        /// <param name="failure">The failure callback.</param>
+        /// <param name="cbObject">The user object sent to the callback.</param>
+        public void GetGroupTournamentStatus(string leaderboardId, string groupId, int versionId = -1, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.LeaderboardId.Value] = leaderboardId;
+            data[OperationParam.GroupId.Value] = groupId;
+            data[OperationParam.VersionId.Value] = versionId;
+
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.GetGroupTournamentStatus, data, callback));
+        }
+        
+        /// <summary>
+        /// Join the specified group division.
+        /// If joining requires a fee, it is possible to fail at joining the division
+        /// </summary>
+        /// <remarks>
+        /// Service Name - tournament
+        /// Service Operation - JOIN_GROUP_DIVISION
+        /// </remarks>
+        /// <param name="divSetId">The id for the division</param>
+        /// <param name="tournamentCode">Tournament to join</param>
+        /// <param name="groupId">The group id</param>
+        /// <param name="initialScore">The initial score for players first joining a tournament</param>
+        /// <param name="success">The success callback.</param>
+        /// <param name="failure">The failure callback.</param>
+        /// <param name="cbObject">The user object sent to the callback.</param>
+         
+        public void JoinGroupDivision(string divSetId, string tournamentCode, string groupId, long initialScore, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.DivSetId.Value] = divSetId;
+            data[OperationParam.TournamentCode.Value] = tournamentCode;
+            data[OperationParam.GroupId.Value] = groupId;
+            data[OperationParam.InitialScore.Value] = initialScore;
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.JoinGroupDivision, data, callback));
+        }
+        
+         /// <summary>
+         /// Join the specified group tournament.
+         /// Any entry fees will be automatically collected.
+         /// </summary>
+         /// <remarks>
+         /// Service Name - tournament
+         /// Service Operation - JOIN_GROUP_TOURNAMENT
+         /// </remarks>
+         /// <param name="leaderboardId">The leaderboard for the tournament</param>
+         /// <param name="tournamentCode">Tournament to join</param>
+         /// <param name="groupId">The group Id</param>
+         /// <param name="initialScore">The initial score for players first joining a tournament, Usually 0, unless leaderboard is LOW_VALUE</param>
+         /// <param name="success">The success callback.</param>
+         /// <param name="failure">The failure callback.</param>
+         /// <param name="cbObject">The user object sent to the callback.</param>
+        public void JoinGroupTournament(string leaderboardId, string tournamentCode, string groupId, long initialScore, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.LeaderboardId.Value] = leaderboardId;
+            data[OperationParam.TournamentCode.Value] = tournamentCode;
+            data[OperationParam.GroupId.Value] = groupId;
+            data[OperationParam.InitialScore.Value] = initialScore;
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.JoinGroupTournament, data, callback));
+        }
+         
+         /// <summary>
+         /// Removes player from group division instance
+         /// Also removes group division instance from player's division list
+         /// </summary>
+         /// <remarks>
+         /// Service Name - tournament
+         /// Service Operation - LEAVE_GROUP_DIVISION_INSTANCE
+         /// </remarks>
+         /// <param name="leaderboardId">The leaderboard for the tournament</param>
+         /// <param name="groupId">The group id</param>
+         /// <param name="success">The success callback.</param>
+         /// <param name="failure">The failure callback.</param>
+         /// <param name="cbObject">The user object sent to the callback.</param>
+        public void LeaveGroupDivisionInstance(string leaderboardId, string groupId, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.LeaderboardId.Value] = leaderboardId;
+            data[OperationParam.GroupId.Value] = groupId;
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.LeaveGroupDivisionInstance, data, callback));
+        }
+        
+        /**
+         * Removes player's score from group tournament leaderboard
+         *
+         * Service Name - tournament
+         * Service Operation - LEAVE_GROUP_TOURNAMENT
+         *
+         * <param name="leaderboardId">The leaderboard for the tournament</param>
+         * <param name="groupId">The group id</param>
+         * <param name="success">The success callback.</param>
+         * <param name="failure">The failure callback.</param>
+         * <param name="cbObject">The user object sent to the callback.</param>
+         */
+        public void LeaveGroupTournament(string leaderboardId, string groupId, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.LeaderboardId.Value] = leaderboardId;
+            data[OperationParam.GroupId.Value] = groupId;
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.LeaveGroupTournament, data, callback));
+        }
+         
+         /// <summary>
+         /// Post the users score to the group leaderboard - UTC time
+         /// </summary>
+         /// <remarks>
+         /// Service Name - tournament
+         /// Service Operation - POST_GROUP_TOURNAMENT_SCORE
+         /// </remarks>
+         ///
+         /// <param name="leaderboardId">The leaderboard for the tournament</param>
+         /// <param name="groupId">The group id</param>
+         /// <param name="score">The score to post</param>
+         /// <param name="jsonData">Optional data attached to the leaderboard entry</param>
+         /// <param name="roundStartedTimeUTC">Time the user started the match resulting in the score being posted in UTC. Use UTC time in milliseconds since epoch</param>
+         /// <param name="success">The success callback.</param>
+         /// <param name="failure">The failure callback.</param>
+         /// <param name="cbObject">The user object sent to the callback.</param> 
+        public void PostGroupTournamentScore(string leaderboardId, string groupId, long score, string jsonData, ulong roundStartedTimeUTC, SuccessCallback success = null, FailureCallback failure = null, object cbObject = null)
+        {
+            var data = new Dictionary<string, object>();
+            data[OperationParam.LeaderboardId.Value] = leaderboardId;
+            data[OperationParam.GroupId.Value] = groupId;
+            data[OperationParam.Score.Value] = score;
+            data[OperationParam.RoundStartedEpoch.Value] = roundStartedTimeUTC;
+            if (Util.IsOptionalParameterValid(jsonData))
+            {
+                Dictionary<string, object> scoreData = JsonReader.Deserialize<Dictionary<string, object>>(jsonData);
+                data[OperationParam.Data.Value] = scoreData;
+            }
+            
+            var callback = BrainCloudClient.CreateServerCallback(success, failure, cbObject);
+            _client.SendRequest(new ServerCall(ServiceName.Tournament, ServiceOperation.PostGroupTournamentScore, data, callback));
+        }
     }
 }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
@@ -426,6 +426,15 @@ namespace BrainCloud
         public static readonly ServiceOperation ViewCurrentReward = new("VIEW_CURRENT_REWARD");
         public static readonly ServiceOperation ViewReward = new("VIEW_REWARD");
         public static readonly ServiceOperation ClaimTournamentReward = new("CLAIM_TOURNAMENT_REWARD");
+        public static readonly ServiceOperation PostGroupTournamentScoreWithResults = new("POST_GROUP_TOURNAMENT_SCORE_WITH_RESULTS");
+        public static readonly ServiceOperation GetGroupDivisionInfo = new("GET_GROUP_DIVISION_INFO");
+        public static readonly ServiceOperation GetGroupDivisions = new("GET_GROUP_DIVISIONS");
+        public static readonly ServiceOperation GetGroupTournamentStatus = new("GET_GROUP_TOURNAMENT_STATUS");
+        public static readonly ServiceOperation JoinGroupDivision = new("JOIN_GROUP_DIVISION");
+        public static readonly ServiceOperation JoinGroupTournament = new("JOIN_GROUP_TOURNAMENT");
+        public static readonly ServiceOperation LeaveGroupTournament = new("LEAVE_GROUP_TOURNAMENT");
+        public static readonly ServiceOperation LeaveGroupDivisionInstance = new("LEAVE_GROUP_DIVISION_INSTANCE");
+        public static readonly ServiceOperation PostGroupTournamentScore = new("POST_GROUP_TOURNAMENT_SCORE");
 
         // rtt
         public static readonly ServiceOperation RequestClientConnection = new("REQUEST_CLIENT_CONNECTION");

--- a/BrainCloudClient/tests/TestTournament.cs
+++ b/BrainCloudClient/tests/TestTournament.cs
@@ -15,6 +15,7 @@ namespace BrainCloudTests
         private readonly string _divSetId = "testDivSetId";
         private readonly string _tournamentCode = "testTournament";
         private readonly string _leaderboardId = "testTournamentLeaderboard";
+        private string _divisionInstanceId;
         private readonly int _score = 10;
         private readonly int _beforeAndAfterCount = 10;
         private readonly int _initialScore = 0;
@@ -52,7 +53,7 @@ namespace BrainCloudTests
         }
 
         [Test]
-        public void GetDivisionInfo()
+        public void GetDivisionInfoExpectFail()
         {
             TestResult tr = new TestResult(_bc);
 
@@ -61,6 +62,18 @@ namespace BrainCloudTests
                 tr.ApiSuccess, tr.ApiError);
 
             tr.RunExpectFail(400, ReasonCodes.DIVISION_SET_DOESNOT_EXIST);
+        }
+        
+        [Test]
+        public void GetDivisionInfo()
+        {
+            TestResult tr = new TestResult(_bc);
+
+            _bc.TournamentService.GetDivisionInfo(
+                _divSetId,
+                tr.ApiSuccess, tr.ApiError);
+
+            tr.Run();
         }
 
         [Test]
@@ -90,7 +103,7 @@ namespace BrainCloudTests
         }
 
         [Test]
-        public void JoinDivision()
+        public void JoinDivisionExpectFail()
         {
             TestResult tr = new TestResult(_bc);
 
@@ -100,6 +113,22 @@ namespace BrainCloudTests
                 _rand.Next(1000),
                 tr.ApiSuccess, tr.ApiError);
             tr.RunExpectFail(400, ReasonCodes.DIVISION_SET_DOESNOT_EXIST);
+            
+        }
+        
+        [Test]
+        public void JoinDivision()
+        {
+            TestResult tr = new TestResult(_bc);
+
+            _bc.TournamentService.JoinDivision(
+                _divSetId,
+                _tournamentCode,
+                _rand.Next(1000),
+                tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+            Dictionary<string, object> data = tr.m_response["data"] as Dictionary<string, object>;
+            _divisionInstanceId = data["leaderboardId"] as string;
             
         }
 
@@ -112,7 +141,7 @@ namespace BrainCloudTests
         }
 
         [Test]
-        public void LeaveDivisionInstance()
+        public void LeaveDivisionInstanceExpectFail()
         {
             TestResult tr = new TestResult(_bc);
             _bc.TournamentService.LeaveDivisionInstance(
@@ -120,6 +149,17 @@ namespace BrainCloudTests
                 tr.ApiSuccess, tr.ApiError
             );
             tr.RunExpectFail(500, ReasonCodes.NO_LEADERBOARD_FOUND);
+        }
+        
+        [Test]
+        public void LeaveDivisionInstance()
+        {
+            TestResult tr = new TestResult(_bc);
+            _bc.TournamentService.LeaveDivisionInstance(
+                _divisionInstanceId,
+                tr.ApiSuccess, tr.ApiError
+            );
+            tr.Run();
         }
 
         [Test]
@@ -194,7 +234,7 @@ namespace BrainCloudTests
         }
 
         [Test]
-        public void ViewReward()
+        public void ViewRewardExpectFail()
         {
             JoinTestTournament();
 

--- a/BrainCloudClient/tests/TestTournament.cs
+++ b/BrainCloudClient/tests/TestTournament.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using BrainCloud.Common;
+using BrainCloud.JsonFx.Json;
 
 namespace BrainCloudTests
 {
@@ -38,7 +39,7 @@ namespace BrainCloudTests
         }
 
         [Test]
-        public void ClaimTournamentReward()
+        public void ClaimTournamentRewardExpectFail()
         {
             int version = JoinTestTournament();
 
@@ -50,6 +51,24 @@ namespace BrainCloudTests
                 tr.ApiSuccess, tr.ApiError);
 
             tr.RunExpectFail(400, ReasonCodes.VIEWING_REWARD_FOR_NON_PROCESSED_TOURNAMENTS);
+        }
+        
+        //[Test] //Disabled because you need a user to join the tournament from yesterday, not sure how to set that up..
+        public void ClaimTournamentReward()
+        {
+            TestResult tr = new TestResult(_bc);
+            
+            _bc.TournamentService.GetTournamentStatus(_leaderboardId, -1, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+
+            var responseData = tr.m_response[OperationParam.Data] as Dictionary<string, object>;
+            int tournamentVersion = (int)responseData[OperationParam.VersionId];
+            
+            _bc.TournamentService.ClaimTournamentReward(
+                _leaderboardId,
+                tournamentVersion - 1,
+                tr.ApiSuccess, tr.ApiError);
+            tr.Run();
         }
 
         [Test]
@@ -248,6 +267,24 @@ namespace BrainCloudTests
             tr.RunExpectFail(400, ReasonCodes.PLAYER_NOT_ENROLLED_IN_TOURNAMENT);
 
             LeaveTestTournament();
+        }
+        
+        //[Test] //Disabled because you need a user to join the tournament from yesterday, not sure how to set that up..
+        public void ViewReward()
+        {
+            TestResult tr = new TestResult(_bc);
+            
+            _bc.TournamentService.GetTournamentStatus(_leaderboardId, -1, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+
+            var responseData = tr.m_response[OperationParam.Data] as Dictionary<string, object>;
+            int tournamentVersion = (int)responseData[OperationParam.VersionId];
+            
+            _bc.TournamentService.ViewReward(
+                _leaderboardId,
+                tournamentVersion - 1,
+                tr.ApiSuccess, tr.ApiError);
+            tr.Run();
         }
         
         [Test]

--- a/BrainCloudClient/tests/TestTournament.cs
+++ b/BrainCloudClient/tests/TestTournament.cs
@@ -5,6 +5,7 @@ using NUnit.Core;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using BrainCloud.Common;
 
 namespace BrainCloudTests
 {
@@ -14,6 +15,15 @@ namespace BrainCloudTests
         private readonly string _divSetId = "testDivSetId";
         private readonly string _tournamentCode = "testTournament";
         private readonly string _leaderboardId = "testTournamentLeaderboard";
+        private readonly int _score = 10;
+        private readonly int _beforeAndAfterCount = 10;
+        private readonly int _initialScore = 0;
+        private readonly string _groupType = "csharpTest";
+        private readonly string _groupName = "csharpTest";
+        private readonly string _divisionGroupSetId = "bronzeGroup";
+        private readonly string _groupTournamentId = "testGroupTournament";
+        private readonly string _groupLeaderboardId = "groupTournament";
+        private string _groupId;
         private Random _rand = new Random();
         private bool _didJoin;
 
@@ -199,6 +209,105 @@ namespace BrainCloudTests
 
             LeaveTestTournament();
         }
+        
+        [Test]
+        public void GetGroupDivisionInfo()
+        {
+            CreateGroup();
+            TestResult tr = new TestResult(_bc);
+            
+            _bc.TournamentService.GetGroupDivisionInfo(_divisionGroupSetId, _groupId, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+
+            DeleteGroup();
+        }
+        
+        [Test]
+        public void GetGroupDivisions()
+        {
+            CreateGroup();
+            TestResult tr = new TestResult(_bc);
+            
+            _bc.TournamentService.GetGroupDivisions(_groupId, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+            
+            DeleteGroup();
+        }
+        
+        [Test]
+        public void GetGroupTournamentStatus()
+        {
+            CreateGroup();
+            TestResult tr = new TestResult(_bc);
+            
+            _bc.TournamentService.GetGroupTournamentStatus(_groupLeaderboardId, _groupId, -1, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+            
+            DeleteGroup();
+        }
+        
+        [Test]
+        public void GroupPostScoreTournamentTest()
+        {
+            CreateGroup();
+            TestResult tr = new TestResult(_bc);
+            
+            Dictionary<string, object> data = new Dictionary<string, object>();
+            //First join division and tournament using group id
+            _bc.TournamentService.JoinGroupDivision(
+                _divisionGroupSetId,
+                _groupTournamentId,
+                _groupId,
+                _initialScore,
+                tr.ApiSuccess, 
+                tr.ApiError
+            );
+            tr.Run();
+            
+            //Get group division leaderboard ID
+            data = tr.m_response[OperationParam.Data] as Dictionary<string, object>;
+            string divisonInstanceId = data[OperationParam.LeaderboardId] as string;
+            
+            _bc.TournamentService.JoinGroupTournament(
+                _groupLeaderboardId, 
+                _groupTournamentId, 
+                _groupId, 
+                _initialScore, 
+                tr.ApiSuccess, 
+                tr.ApiError);
+            tr.Run();
+            
+            _bc.TournamentService.PostGroupTournamentScoreWithResults(
+                _groupLeaderboardId,
+                _groupId,
+                _score,
+                "{}",
+                (UInt64)((TimeZoneInfo.ConvertTimeToUtc(DateTime.UtcNow) - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds),
+                BrainCloudSocialLeaderboard.SortOrder.HIGH_TO_LOW,
+                _beforeAndAfterCount,
+                _beforeAndAfterCount,
+                _initialScore,
+                tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+            
+            _bc.TournamentService.PostGroupTournamentScore(
+                _groupLeaderboardId,
+                _groupId,
+                _score,
+                "{}",
+                (UInt64)((TimeZoneInfo.ConvertTimeToUtc(DateTime.UtcNow) - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds),
+                tr.ApiSuccess,
+                tr.ApiError);
+            tr.Run();
+            
+            _bc.TournamentService.LeaveGroupDivisionInstance(divisonInstanceId, _groupId, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+            
+            _bc.TournamentService.LeaveGroupTournament(_groupLeaderboardId, _groupId, tr.ApiSuccess, tr.ApiError);
+            tr.Run();
+            
+            DeleteGroup();
+        }
 
 
         // Helpers
@@ -236,6 +345,38 @@ namespace BrainCloudTests
             tr.Run();
             _didJoin = false;
         }
+        
+        private void CreateGroup()
+        {
+            TestResult tr = new TestResult(_bc);
+            _bc.GroupService.CreateGroup(
+                _groupName, 
+                _groupType, 
+                true, 
+                new GroupACL(GroupACL.Access.ReadWrite, GroupACL.Access.ReadWrite),
+                "{}", 
+                Helpers.CreateJsonPair("testInc", 123),
+                Helpers.CreateJsonPair("test", "test"),
+                tr.ApiSuccess, 
+                tr.ApiError
+            );
+            tr.Run();
 
+            Dictionary<string, object> data = tr.m_response["data"] as Dictionary<string, object>;
+            
+            _groupId = data["groupId"] as string;
+        }
+        
+        private void DeleteGroup()
+        {
+            TestResult tr = new TestResult(_bc);
+            _bc.GroupService.DeleteGroup(
+                _groupId,
+                -1,
+                tr.ApiSuccess, 
+                tr.ApiError
+            );
+            tr.Run();
+        }
     }
 }


### PR DESCRIPTION
API and Test implemented for the following:
- BCLOUD-12716 - PostGroupTournamentScoreWithResults
- BCLOUD-12705 - PostGroupTournamentScore
- BCLOUD-12694 - GetGroupDivisions
- BCLOUD-12683 - LeaveGroupDivisionInstance
- BCLOUD-12672 - LeaveGroupTournament
- BCLOUD-12661 - JoinGroupDivision
- BCLOUD-12650 - JoinGroupTournament
- BCLOUD-12639 - GetGroupDivisionInfo
- BCLOUD-12628 - GetGroupTournamentStatus

Test Results included in text file:
[Test Results For Group Tournament Testing.txt](https://github.com/user-attachments/files/25588609/Test.Results.For.Group.Tournament.Testing.txt)
