### PR TITLE
[BCLOUD-12993] Add visionOS Platform

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
@@ -20,54 +20,56 @@ namespace BrainCloud.Common
         #region brainCloud Platforms
 
         public static readonly Platform Unknown           = new("UNKNOWN");
+        public static readonly Platform Amazon            = new("AMAZON");
         public static readonly Platform AppleTVOS         = new("APPLE_TV_OS");
         public static readonly Platform BlackBerry        = new("BB");
         public static readonly Platform Facebook          = new("FB");
-        public static readonly Platform Oculus            = new("OCULUS");
         public static readonly Platform GooglePlayAndroid = new("ANG");
         public static readonly Platform iOS               = new("IOS");
         public static readonly Platform Linux             = new("LINUX");
         public static readonly Platform Mac               = new("MAC");
+        public static readonly Platform Nintendo          = new("NINTENDO");
+        public static readonly Platform Oculus            = new("OCULUS");
         public static readonly Platform PS3               = new("PS3");
         public static readonly Platform PS4               = new("PS4");
         public static readonly Platform PSVita            = new("PS_VITA");
         public static readonly Platform Roku              = new("ROKU");
         public static readonly Platform Tizen             = new("TIZEN");
+        public static readonly Platform VisionOS          = new("VISION_OS");
         public static readonly Platform WatchOS           = new("WATCH_OS");
         public static readonly Platform Web               = new("WEB");
         public static readonly Platform Wii               = new("WII");
-        public static readonly Platform WindowsPhone      = new("WINP");
         public static readonly Platform Windows           = new("WINDOWS");
+        public static readonly Platform WindowsPhone      = new("WINP");
         public static readonly Platform Xbox360           = new("XBOX_360");
         public static readonly Platform XboxOne           = new("XBOX_ONE");
-        public static readonly Platform Amazon            = new("AMAZON");
-        public static readonly Platform Nintendo          = new("NINTENDO");
 
         private static readonly Dictionary<string, Platform> _platformsForString = new()
         {
             { Unknown.value,           Unknown           },
-            { AppleTVOS.value,         AppleTVOS         },
             { Amazon.value,            Amazon            },
+            { AppleTVOS.value,         AppleTVOS         },
             { BlackBerry.value,        BlackBerry        },
             { Facebook.value,          Facebook          },
-            { Oculus.value,            Oculus            },
             { GooglePlayAndroid.value, GooglePlayAndroid },
             { iOS.value,               iOS               },
             { Linux.value,             Linux             },
             { Mac.value,               Mac               },
+            { Nintendo.value,          Nintendo          },
+            { Oculus.value,            Oculus            },
             { PS3.value,               PS3               },
             { PS4.value,               PS4               },
             { PSVita.value,            PSVita            },
             { Roku.value,              Roku              },
             { Tizen.value,             Tizen             },
+            { VisionOS.value,          VisionOS          },
             { WatchOS.value,           WatchOS           },
             { Web.value,               Web               },
             { Wii.value,               Wii               },
-            { WindowsPhone.value,      WindowsPhone      },
             { Windows.value,           Windows           },
+            { WindowsPhone.value,      WindowsPhone      },
             { Xbox360.value,           Xbox360           },
-            { XboxOne.value,           XboxOne           },
-            { Nintendo.value,          Nintendo          }
+            { XboxOne.value,           XboxOne           }
         };
 
         #endregion
@@ -113,21 +115,23 @@ namespace BrainCloud.Common
             return iOS;
 #elif UNITY_TVOS
             return AppleTVOS;
+#elif UNITY_VISIONOS
+            return VisionOS;
 #elif UNITY_ANDROID
             string check = UnityEngine.SystemInfo.deviceModel.ToLower();
-            if (check.Contains("amazon"))
-            {
-                return Amazon;
-            }
+            if (check.Contains("amazon"))
+            {
+                return Amazon;
+            }
             else if (check.Contains("oculus") ||
                      check.Contains("quest"))
             {
                 return Oculus;
             }
-            else
-            {
-                return GooglePlayAndroid;
-            }
+            else
+            {
+                return GooglePlayAndroid;
+            }
 #elif UNITY_WP8 || UNITY_WP8_1
             return WindowsPhone;
 #elif UNITY_WSA
@@ -144,21 +148,6 @@ namespace BrainCloud.Common
             return XboxOne;
 #elif UNITY_TIZEN
             return Tizen;
-#elif XAMARIN
-            string check = DeviceInfo.Manufacturer.ToLower();
-            if (check.Contains("amazon"))
-            {
-                return Amazon;
-            }
-            else if (check.Contains("oculus") ||
-                     check.Contains("quest"))
-            {
-                return Oculus;
-            }
-            else
-            {
-                return GooglePlayAndroid;
-            }
 #elif UNITY_SWITCH
             return Nintendo;
 #else
@@ -170,62 +159,67 @@ namespace BrainCloud.Common
 #endif
 
 #if GODOT
-	public static Platform GodotFromRuntime()
-	{
-		Platform platform = Platform.Unknown;
-		switch(OS.GetName())
-		{
-			case "Windows":
-				platform = Platform.Windows;
-				break;
-			case "macOS":
-				platform = Platform.Mac;
-				break;
-			case "Linux":
-				platform = Platform.Linux;
-				break;
-			case "Android":
-				platform = Platform.GooglePlayAndroid;
-				break;
-			case "iOS":
-				platform = Platform.iOS;
-				break;
-			case "Web":
-				platform = Platform.Web;
-				break;
-		}
-		return platform;
-	}
+        public static Platform GodotFromRuntime()
+        {
+            Platform platform = Unknown;
+            switch(OS.GetName())
+            {
+                case "Windows":
+                    platform = Windows;
+                    break;
+                case "macOS":
+                    platform = Mac;
+                    break;
+                case "Linux":
+                case "FreeBSD":
+                case "NetBSD":
+                case "OpenBSD":
+                case "BSD":
+                    platform = Linux;
+                    break;
+                case "Android":
+                    platform = GooglePlayAndroid;
+                    break;
+                case "iOS":
+                    platform = iOS;
+                    break;
+                case "Web":
+                    platform = Web;
+                    break;
+            }
+
+            return platform;
+        }
 #endif
 
 #if XAMARIN
-
-    public static Platform FromRuntime()
-    {
-        Platform platform = Platform.Unknown;
-        try
+        public static Platform FromRuntime()
         {
-            switch (Device.RuntimePlatform)
+            Platform platform = Unknown;
+            try
             {
-                case Device.iOS:
-                    platform = Platform.iOS;
-                    break;
-                case Device.macOS:
-                    platform = Platform.Mac;
-                    break;
-                case Device.Android:
-                    platform = Platform.GooglePlayAndroid;
-                    break;
-                case Device.WPF:
-                    platform = Platform.Windows;
-                    break;
+                switch (Device.RuntimePlatform)
+                {
+                    case Device.iOS:
+                        platform = iOS;
+                        break;
+                    case Device.macOS:
+                        platform = Mac;
+                        break;
+                    case Device.Android:
+                        platform = GooglePlayAndroid;
+                        break;
+                    case Device.WPF:
+                        platform = Windows;
+                        break;
+                }
             }
-        }
-        catch{}
+            catch{}
 
-        return platform;
-    }
+            return platform;
+        }
 #endif
+
         #region Overrides and Operators
 
         public readonly override bool Equals(object obj)

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
@@ -94,7 +94,6 @@ namespace BrainCloud.Common
             return Unknown;
 #else
             // First deal with Platforms that have no defines
-
             // 5.0 and later
 #if !UNITY_4_6 && !UNITY_2018_3_OR_NEWER
             if (UnityEngine.Application.platform == UnityEngine.RuntimePlatform.PSP2)
@@ -105,18 +104,25 @@ namespace BrainCloud.Common
             // Otherwise we rely on the Unity compile flag to denote Platform
 #if UNITY_STANDALONE_WIN
             return Windows;
-#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+#elif UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_IPHONE || UNITY_TVOS || UNITY_VISIONOS
+            var platform = UnityEngine.Device.Application.platform;
+            if (platform == UnityEngine.RuntimePlatform.IPhonePlayer)
+            {
+                return iOS;
+            }
+            else if (platform == UnityEngine.RuntimePlatform.tvOS)
+            {
+                return AppleTVOS;
+            }
+            else if (platform == UnityEngine.RuntimePlatform.VisionOS)
+            {
+                return VisionOS;
+            }
             return Mac;
 #elif UNITY_STANDALONE_LINUX
             return Linux;
 #elif UNITY_WEBPLAYER || UNITY_WEBGL
             return Web;
-#elif UNITY_IOS || UNITY_IPHONE
-            return iOS;
-#elif UNITY_TVOS
-            return AppleTVOS;
-#elif UNITY_VISIONOS
-            return VisionOS;
 #elif UNITY_ANDROID
             string check = UnityEngine.SystemInfo.deviceModel.ToLower();
             if (check.Contains("amazon"))

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -2622,7 +2622,7 @@ namespace BrainCloud.Internal
             JsonParser.GetJsonResponseBundleV2(jsonData, out string packetId, out string events, out string[] responses);
 
             this.packetId = long.TryParse(packetId, out long result) ? result : NO_PACKET_EXPECTED;
-            if (this.packetId < 0)
+            if (this.packetId < NO_PACKET_EXPECTED)
             {
                 throw new Exception($"packetId is not a valid value! packetId: {this.packetId}");
             }


### PR DESCRIPTION
Added `VISION_OS` as a platform. Tested it in the simulator.

Also alphabetized the platforms, I can't help myself 😅 

<img width="3594" height="2174" alt="image" src="https://github.com/user-attachments/assets/605f9a1c-6c08-4641-9250-3773625c3cf5" />
