### PR TITLE
Remove ReferenceEquals for structs

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/AuthenticationType.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/AuthenticationType.cs
@@ -84,9 +84,6 @@ namespace BrainCloud.Common
             if (GetType() != other.GetType())
                 return false;
 
-            if (ReferenceEquals(this, other))
-                return true;
-
             return value == other.value;
         }
 
@@ -94,9 +91,6 @@ namespace BrainCloud.Common
         {
             if (GetType() != other.GetType())
                 return 1;
-
-            if (ReferenceEquals(this, other))
-                return 0;
 
             return value.CompareTo(other.value);
         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
@@ -241,9 +241,6 @@ namespace BrainCloud.Common
             if (GetType() != other.GetType())
                 return false;
 
-            if (ReferenceEquals(this, other))
-                return true;
-
             return value == other.value;
         }
 
@@ -251,9 +248,6 @@ namespace BrainCloud.Common
         {
             if (GetType() != other.GetType())
                 return 1;
-
-            if (ReferenceEquals(this, other))
-                return 0;
 
             return value.CompareTo(other.value);
         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/OperationParam.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/OperationParam.cs
@@ -620,9 +620,6 @@ namespace BrainCloud
             if (GetType() != other.GetType())
                 return false;
 
-            if (ReferenceEquals(this, other))
-                return true;
-
             return Value == other.Value;
         }
 
@@ -630,9 +627,6 @@ namespace BrainCloud
         {
             if (GetType() != other.GetType())
                 return 1;
-
-            if (ReferenceEquals(this, other))
-                return 0;
 
             return Value.CompareTo(other.Value);
         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceName.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceName.cs
@@ -81,9 +81,6 @@ namespace BrainCloud
             if (GetType() != other.GetType())
                 return false;
 
-            if (ReferenceEquals(this, other))
-                return true;
-
             return Value == other.Value;
         }
 
@@ -91,9 +88,6 @@ namespace BrainCloud
         {
             if (GetType() != other.GetType())
                 return 1;
-
-            if (ReferenceEquals(this, other))
-                return 0;
 
             return Value.CompareTo(other.Value);
         }

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
@@ -560,9 +560,6 @@ namespace BrainCloud
             if (GetType() != other.GetType())
                 return false;
 
-            if (ReferenceEquals(this, other))
-                return true;
-
             return Value == other.Value;
         }
 
@@ -570,9 +567,6 @@ namespace BrainCloud
         {
             if (GetType() != other.GetType())
                 return 1;
-
-            if (ReferenceEquals(this, other))
-                return 0;
 
             return Value.CompareTo(other.Value);
         }


### PR DESCRIPTION
Removing `ReferenceEquals` on structs because it's not needed for structs and is leading to warnings.