### PR TITLE
Maintain Older Unity Compatibility

### DIFF
--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/AuthenticationType.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/AuthenticationType.cs
@@ -7,33 +7,33 @@ using System.Collections.Generic;
 
 namespace BrainCloud.Common
 {
-    public readonly struct AuthenticationType : System.IEquatable<AuthenticationType>, System.IComparable<AuthenticationType>
+    public readonly struct AuthenticationType : System.IEquatable<AuthenticationType>, System.IComparable, System.IComparable<AuthenticationType>
     {
         #region brainCloud Authentication Types
 
-        public static readonly AuthenticationType Anonymous           = new("Anonymous");
-        public static readonly AuthenticationType Universal           = new("Universal");
-        public static readonly AuthenticationType Email               = new("Email");
-        public static readonly AuthenticationType Facebook            = new("Facebook");
-        public static readonly AuthenticationType FacebookLimited     = new("FacebookLimited");
-        public static readonly AuthenticationType Oculus              = new("Oculus");
-        public static readonly AuthenticationType PlaystationNetwork  = new("PlaystationNetwork");
-        public static readonly AuthenticationType PlaystationNetwork5 = new("PlaystationNetwork5");
-        public static readonly AuthenticationType GameCenter          = new("GameCenter");
-        public static readonly AuthenticationType Steam               = new("Steam");
-        public static readonly AuthenticationType Apple               = new("Apple");
-        public static readonly AuthenticationType Google              = new("Google");
-        public static readonly AuthenticationType GoogleOpenId        = new("GoogleOpenId");
-        public static readonly AuthenticationType Twitter             = new("Twitter");
-        public static readonly AuthenticationType Parse               = new("Parse");
-        public static readonly AuthenticationType External            = new("External");
-        public static readonly AuthenticationType Handoff             = new("Handoff");
-        public static readonly AuthenticationType SettopHandoff       = new("SettopHandoff");
-        public static readonly AuthenticationType Ultra               = new("Ultra");
-        public static readonly AuthenticationType Nintendo            = new("Nintendo");
-        public static readonly AuthenticationType Unknown             = new("UNKNOWN");
+        public static readonly AuthenticationType Anonymous           = new AuthenticationType("Anonymous");
+        public static readonly AuthenticationType Universal           = new AuthenticationType("Universal");
+        public static readonly AuthenticationType Email               = new AuthenticationType("Email");
+        public static readonly AuthenticationType Facebook            = new AuthenticationType("Facebook");
+        public static readonly AuthenticationType FacebookLimited     = new AuthenticationType("FacebookLimited");
+        public static readonly AuthenticationType Oculus              = new AuthenticationType("Oculus");
+        public static readonly AuthenticationType PlaystationNetwork  = new AuthenticationType("PlaystationNetwork");
+        public static readonly AuthenticationType PlaystationNetwork5 = new AuthenticationType("PlaystationNetwork5");
+        public static readonly AuthenticationType GameCenter          = new AuthenticationType("GameCenter");
+        public static readonly AuthenticationType Steam               = new AuthenticationType("Steam");
+        public static readonly AuthenticationType Apple               = new AuthenticationType("Apple");
+        public static readonly AuthenticationType Google              = new AuthenticationType("Google");
+        public static readonly AuthenticationType GoogleOpenId        = new AuthenticationType("GoogleOpenId");
+        public static readonly AuthenticationType Twitter             = new AuthenticationType("Twitter");
+        public static readonly AuthenticationType Parse               = new AuthenticationType("Parse");
+        public static readonly AuthenticationType External            = new AuthenticationType("External");
+        public static readonly AuthenticationType Handoff             = new AuthenticationType("Handoff");
+        public static readonly AuthenticationType SettopHandoff       = new AuthenticationType("SettopHandoff");
+        public static readonly AuthenticationType Ultra               = new AuthenticationType("Ultra");
+        public static readonly AuthenticationType Nintendo            = new AuthenticationType("Nintendo");
+        public static readonly AuthenticationType Unknown             = new AuthenticationType("UNKNOWN");
 
-        private static readonly Dictionary<string, AuthenticationType> _typesForString = new()
+        private static readonly Dictionary<string, AuthenticationType> _typesForString = new Dictionary<string, AuthenticationType>()
         {
             { Anonymous.value,          Anonymous          },
             { Universal.value,          Universal          },
@@ -71,33 +71,34 @@ namespace BrainCloud.Common
 
         #region Overrides and Operators
 
-        public readonly override bool Equals(object obj)
+        public override bool Equals(object obj)
         {
-            if (obj is not AuthenticationType s)
-                return false;
-
-            return Equals(s);
+            return obj is AuthenticationType other && Equals(other);
         }
 
-        public readonly bool Equals(AuthenticationType other)
+        public bool Equals(AuthenticationType other)
         {
-            if (GetType() != other.GetType())
-                return false;
-
             return value == other.value;
         }
 
-        public readonly int CompareTo(AuthenticationType other)
+        public int CompareTo(object obj)
         {
-            if (GetType() != other.GetType())
-                return 1;
+            if (obj is AuthenticationType other)
+            {
+                return CompareTo(other);
+            }
 
+            return 1;
+        }
+
+        public int CompareTo(AuthenticationType other)
+        {
             return value.CompareTo(other.value);
         }
 
-        public readonly override int GetHashCode() => value.GetHashCode();
+        public override int GetHashCode() => value.GetHashCode();
 
-        public readonly override string ToString() => value;
+        public override string ToString() => value;
 
         public static implicit operator string(AuthenticationType v) => v.value;
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/JsonParser.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/JsonParser.cs
@@ -21,11 +21,27 @@ namespace BrainCloud
 
             [ThreadStatic]
             private static StringBuilder _sbHelper;
-            private static StringBuilder sbHelper => _sbHelper ??= new(2048);
+            private static StringBuilder SBHelper
+            {
+                get
+                {
+                    if (_sbHelper == null)
+                        _sbHelper = new StringBuilder(2048);
+                    return _sbHelper;
+                }
+            }
 
             [ThreadStatic]
             private static List<string> _splitArrays;
-            private static List<string> splitArrays => _splitArrays ??= new(4);
+            private static List<string> SplitArrays
+            {
+                get
+                {
+                    if (_splitArrays == null)
+                        _splitArrays = new List<string>(4);
+                    return _splitArrays;
+                }
+            }
 
             // This is a helper function for the hierarchy functions to get the hierarchy minus the last value.
             private static string[] GetHierarchyMinusOne(string[] hierarchy)
@@ -75,17 +91,17 @@ namespace BrainCloud
                         insideProperty = !insideProperty;
                         if (insideProperty)
                         {
-                            sbHelper.Clear();
+                            SBHelper.Clear();
                         }
                     }
                     else if (!insideProperty && current == ':')
                     {
                         next = jsonData[i + 1];
-                        if (sbHelper.ToString() == property)
+                        if (SBHelper.ToString() == property)
                         {
                             if (next == '{' || next == '[')
                             {
-                                sbHelper.Clear();
+                                SBHelper.Clear();
 
                                 int level = 0;
 
@@ -110,7 +126,7 @@ namespace BrainCloud
                                                 {
                                                     current = jsonData[i - 1];
                                                     next = jsonData[i];
-                                                    sbHelper.Append(current);
+                                                    SBHelper.Append(current);
 
                                                     if (next == '"' && current != '\\')
                                                     {
@@ -123,18 +139,18 @@ namespace BrainCloud
                                             }
                                             goto default;
                                         default:
-                                            sbHelper.Append(current);
+                                            SBHelper.Append(current);
                                             continue;
                                     }
                                 }
                                 while (level > 0);
 
-                                return sbHelper.ToString();
+                                return SBHelper.ToString();
                             }
                             else // Not an array or object
                             {
                                 i++;
-                                sbHelper.Clear();
+                                SBHelper.Clear();
                                 if (next == '"') // String value
                                 {
                                     i++;
@@ -142,7 +158,7 @@ namespace BrainCloud
                                     {
                                         current = jsonData[i - 1];
                                         next = jsonData[i];
-                                        sbHelper.Append(current);
+                                        SBHelper.Append(current);
 
                                         if (next == '"' && current != '\\')
                                         {
@@ -150,9 +166,9 @@ namespace BrainCloud
                                         }
                                     }
 
-                                    if (sbHelper.ToString() == "\"" || sbHelper.ToString() == "\",") // We must have grabbed an empty string
+                                    if (SBHelper.ToString() == "\"" || SBHelper.ToString() == "\",") // We must have grabbed an empty string
                                     {
-                                        sbHelper.Clear();
+                                        SBHelper.Clear();
                                     }
                                     else if (i >= jsonData.Length)
                                     {
@@ -165,11 +181,11 @@ namespace BrainCloud
                                     {
                                         current = jsonData[i];
                                         next = jsonData[++i];
-                                        sbHelper.Append(current);
+                                        SBHelper.Append(current);
                                     }
                                 }
 
-                                return sbHelper.ToString();
+                                return SBHelper.ToString();
                             }
                         }
                         else if (next == '{' || next == '[')
@@ -216,7 +232,7 @@ namespace BrainCloud
                     }
                     else if (insideProperty)
                     {
-                        sbHelper.Append(current);
+                        SBHelper.Append(current);
                     }
                 }
 
@@ -299,7 +315,7 @@ namespace BrainCloud
 
                 char current;
                 int i = 0, level = 1, start = 1; // start after '['
-                splitArrays.Clear();
+                SplitArrays.Clear();
 
                 while (level > 0 && ++i < jsonData.Length)
                 {
@@ -325,7 +341,7 @@ namespace BrainCloud
                                         array = array.Substring(1, array.Length - 2);
                                     }
 
-                                    splitArrays.Add(array);
+                                    SplitArrays.Add(array);
                                 }
                             }
                             break;
@@ -338,7 +354,7 @@ namespace BrainCloud
                                     array = array.Substring(1, array.Length - 2);
                                 }
 
-                                splitArrays.Add(array);
+                                SplitArrays.Add(array);
                                 start = i + 1;
                             }
                             break;
@@ -357,7 +373,7 @@ namespace BrainCloud
                     }
                 }
 
-                return splitArrays.Count > 0 ? splitArrays.ToArray() : null;
+                return SplitArrays.Count > 0 ? SplitArrays.ToArray() : null;
             }
 
             /// <summary>
@@ -420,8 +436,8 @@ namespace BrainCloud
             /// <param name="property">The name of the property you want within the Json string's highest hierarchy layer.</param>
             /// <returns>
             /// The value for the property name if it is a valid non-nullable <b>struct</b> and <see cref="IConvertible"/> value type.
-            /// <br><b>Note¹</b>: If the property isn't valid or not found it will return a <see cref="default"/> value.</br>
-            /// <br><b>Note²</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
+            /// <br><b>Noteï¿½</b>: If the property isn't valid or not found it will return a <see cref="default"/> value.</br>
+            /// <br><b>Noteï¿½</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
             ///                   Exceptions are if the value is a number that is <b>0</b>, if the value is <b>false</b>, if the value is <b>null</b>, or if the value is an empty <b>object</b> or <b>array</b>.</br>
             /// </returns>
             public static T GetValue<T>(string jsonData, string property) where T : struct, IConvertible
@@ -461,8 +477,8 @@ namespace BrainCloud
             /// <param name="hierarchy">The list of properties, in progressive order, to parse through the Json string's object hierarchy.</param>
             /// <returns>
             /// The value for the property name at the end of the hierarchy if it is a valid non-nullable <b>struct</b> and <see cref="IConvertible"/> value type.
-            /// <br><b>Note¹</b>: If the hierarchy isn't valid or the property is not found it will return a <see cref="default"/> value.</br>
-            /// <br><b>Note²</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
+            /// <br><b>Noteï¿½</b>: If the hierarchy isn't valid or the property is not found it will return a <see cref="default"/> value.</br>
+            /// <br><b>Noteï¿½</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
             ///                   Exceptions are if the value is a number that is <b>0</b>, if the value is <b>false</b>, if the value is <b>null</b>, or if the value is an empty <b>object</b> or <b>array</b>.</br>
             /// </returns>
             public static T GetValue<T>(string jsonData, params string[] hierarchy) where T : struct, IConvertible

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/JsonParser.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/JsonParser.cs
@@ -436,8 +436,8 @@ namespace BrainCloud
             /// <param name="property">The name of the property you want within the Json string's highest hierarchy layer.</param>
             /// <returns>
             /// The value for the property name if it is a valid non-nullable <b>struct</b> and <see cref="IConvertible"/> value type.
-            /// <br><b>Note�</b>: If the property isn't valid or not found it will return a <see cref="default"/> value.</br>
-            /// <br><b>Note�</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
+            /// <br><b>Note1</b>: If the property isn't valid or not found it will return a <see cref="default"/> value.</br>
+            /// <br><b>Note2</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
             ///                   Exceptions are if the value is a number that is <b>0</b>, if the value is <b>false</b>, if the value is <b>null</b>, or if the value is an empty <b>object</b> or <b>array</b>.</br>
             /// </returns>
             public static T GetValue<T>(string jsonData, string property) where T : struct, IConvertible
@@ -477,8 +477,8 @@ namespace BrainCloud
             /// <param name="hierarchy">The list of properties, in progressive order, to parse through the Json string's object hierarchy.</param>
             /// <returns>
             /// The value for the property name at the end of the hierarchy if it is a valid non-nullable <b>struct</b> and <see cref="IConvertible"/> value type.
-            /// <br><b>Note�</b>: If the hierarchy isn't valid or the property is not found it will return a <see cref="default"/> value.</br>
-            /// <br><b>Note�</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
+            /// <br><b>Note1</b>: If the hierarchy isn't valid or the property is not found it will return a <see cref="default"/> value.</br>
+            /// <br><b>Note2</b>: If you are trying to get a <see cref="bool"/> value then this will return <b>true</b> if the property contains <b>any</b> kind of value.
             ///                   Exceptions are if the value is a number that is <b>0</b>, if the value is <b>false</b>, if the value is <b>null</b>, or if the value is an empty <b>object</b> or <b>array</b>.</br>
             /// </returns>
             public static T GetValue<T>(string jsonData, params string[] hierarchy) where T : struct, IConvertible

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
@@ -165,7 +165,7 @@ namespace BrainCloud.Common
 #endif
 
 #if GODOT
-	    public static Platform GodotFromRuntime()
+        public static Platform GodotFromRuntime()
         {
             Platform platform = Unknown;
             switch(OS.GetName())

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
@@ -15,36 +15,36 @@ using Godot;
 
 namespace BrainCloud.Common
 {
-    public readonly struct Platform : System.IEquatable<Platform>, System.IComparable<Platform>
+    public readonly struct Platform : System.IEquatable<Platform>, System.IComparable, System.IComparable<Platform>
     {
         #region brainCloud Platforms
 
-        public static readonly Platform Unknown           = new("UNKNOWN");
-        public static readonly Platform Amazon            = new("AMAZON");
-        public static readonly Platform AppleTVOS         = new("APPLE_TV_OS");
-        public static readonly Platform BlackBerry        = new("BB");
-        public static readonly Platform Facebook          = new("FB");
-        public static readonly Platform GooglePlayAndroid = new("ANG");
-        public static readonly Platform iOS               = new("IOS");
-        public static readonly Platform Linux             = new("LINUX");
-        public static readonly Platform Mac               = new("MAC");
-        public static readonly Platform Nintendo          = new("NINTENDO");
-        public static readonly Platform Oculus            = new("OCULUS");
-        public static readonly Platform PS3               = new("PS3");
-        public static readonly Platform PS4               = new("PS4");
-        public static readonly Platform PSVita            = new("PS_VITA");
-        public static readonly Platform Roku              = new("ROKU");
-        public static readonly Platform Tizen             = new("TIZEN");
-        public static readonly Platform VisionOS          = new("VISION_OS");
-        public static readonly Platform WatchOS           = new("WATCH_OS");
-        public static readonly Platform Web               = new("WEB");
-        public static readonly Platform Wii               = new("WII");
-        public static readonly Platform Windows           = new("WINDOWS");
-        public static readonly Platform WindowsPhone      = new("WINP");
-        public static readonly Platform Xbox360           = new("XBOX_360");
-        public static readonly Platform XboxOne           = new("XBOX_ONE");
+        public static readonly Platform Unknown           = new Platform("UNKNOWN");
+        public static readonly Platform Amazon            = new Platform("AMAZON");
+        public static readonly Platform AppleTVOS         = new Platform("APPLE_TV_OS");
+        public static readonly Platform BlackBerry        = new Platform("BB");
+        public static readonly Platform Facebook          = new Platform("FB");
+        public static readonly Platform GooglePlayAndroid = new Platform("ANG");
+        public static readonly Platform iOS               = new Platform("IOS");
+        public static readonly Platform Linux             = new Platform("LINUX");
+        public static readonly Platform Mac               = new Platform("MAC");
+        public static readonly Platform Nintendo          = new Platform("NINTENDO");
+        public static readonly Platform Oculus            = new Platform("OCULUS");
+        public static readonly Platform PS3               = new Platform("PS3");
+        public static readonly Platform PS4               = new Platform("PS4");
+        public static readonly Platform PSVita            = new Platform("PS_VITA");
+        public static readonly Platform Roku              = new Platform("ROKU");
+        public static readonly Platform Tizen             = new Platform("TIZEN");
+        public static readonly Platform VisionOS          = new Platform("VISION_OS");
+        public static readonly Platform WatchOS           = new Platform("WATCH_OS");
+        public static readonly Platform Web               = new Platform("WEB");
+        public static readonly Platform Wii               = new Platform("WII");
+        public static readonly Platform Windows           = new Platform("WINDOWS");
+        public static readonly Platform WindowsPhone      = new Platform("WINP");
+        public static readonly Platform Xbox360           = new Platform("XBOX_360");
+        public static readonly Platform XboxOne           = new Platform("XBOX_ONE");
 
-        private static readonly Dictionary<string, Platform> _platformsForString = new()
+        private static readonly Dictionary<string, Platform> _platformsForString = new Dictionary<string, Platform>()
         {
             { Unknown.value,           Unknown           },
             { Amazon.value,            Amazon            },
@@ -165,7 +165,7 @@ namespace BrainCloud.Common
 #endif
 
 #if GODOT
-        public static Platform GodotFromRuntime()
+	public static Platform GodotFromRuntime()
         {
             Platform platform = Unknown;
             switch(OS.GetName())
@@ -228,33 +228,34 @@ namespace BrainCloud.Common
 
         #region Overrides and Operators
 
-        public readonly override bool Equals(object obj)
+        public override bool Equals(object obj)
         {
-            if (obj is not Platform s)
-                return false;
-
-            return Equals(s);
+            return obj is Platform other && Equals(other);
         }
 
-        public readonly bool Equals(Platform other)
+        public bool Equals(Platform other)
         {
-            if (GetType() != other.GetType())
-                return false;
-
             return value == other.value;
         }
 
-        public readonly int CompareTo(Platform other)
+        public int CompareTo(object obj)
         {
-            if (GetType() != other.GetType())
-                return 1;
+            if (obj is Platform other)
+            {
+                return CompareTo(other);
+            }
 
+            return 1;
+        }
+
+        public int CompareTo(Platform other)
+        {
             return value.CompareTo(other.value);
         }
 
-        public readonly override int GetHashCode() => value.GetHashCode();
+        public override int GetHashCode() => value.GetHashCode();
 
-        public readonly override string ToString() => value;
+        public override string ToString() => value;
 
         public static implicit operator string(Platform v) => v.value;
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Common/Platform.cs
@@ -165,7 +165,7 @@ namespace BrainCloud.Common
 #endif
 
 #if GODOT
-	public static Platform GodotFromRuntime()
+	    public static Platform GodotFromRuntime()
         {
             Platform platform = Unknown;
             switch(OS.GetName())

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -3,6 +3,8 @@
 // brainCloud client source code
 //----------------------------------------------------
 
+//#define JSON_COMPATIBILITY_FLAG // Uncomment this if you're using a Json serializer that is having trouble with stripping out trailing .0s for number values
+
 #if (UNITY_5_3_OR_NEWER && !UNITY_WEBPLAYER && (!UNITY_IOS || ENABLE_IL2CPP)) || UNITY_2018_3_OR_NEWER
 #define USE_WEB_REQUEST // Comment out to force use of old WWW class on Unity 5.3+
 using BrainCloud.UnityWebSocketsForWebGL.WebSocketSharp;
@@ -998,6 +1000,14 @@ namespace BrainCloud.Internal
         /// <param name="jsonData">The received message bundle.</param>
         private void HandleResponseBundle(string jsonData)
         {
+#if JSON_COMPATIBILITY_FLAG
+            jsonData = jsonData.Trim();
+            if ((jsonData.StartsWith("{") && jsonData.EndsWith("}")) ||
+                (jsonData.StartsWith("[") && jsonData.EndsWith("]")))
+            {
+                jsonData = SerializeJson(JsonReader.Deserialize(jsonData)); // This will strip any leading .0 for int values, replicating the behaviour from 5.9.2 and older
+            }
+#endif
             void logToClient(string log)
             {
                 if (_clientRef.LoggingEnabled)
@@ -1721,7 +1731,7 @@ namespace BrainCloud.Internal
 
         internal string SerializeJson(object payload)
         {
-            //Unity doesn't like when we create a new StringBuilder outside of this method.
+            // Unity doesn't like when we create a new StringBuilder outside of this method.
             _stringBuilderOutput = new StringBuilder();
             using (JsonWriter writer = new JsonWriter(_stringBuilderOutput, _writerSettings))
             {

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/Internal/BrainCloudComms.cs
@@ -325,7 +325,7 @@ namespace BrainCloud.Internal
         /// <summary>
         /// A list of packet timeouts. Index represents the packet attempt number.
         /// </summary>
-        private List<int> _packetTimeouts = new() { 15, 20, 35, 50 };
+        private List<int> _packetTimeouts = new List<int>() { 15, 20, 35, 50 };
         public List<int> PacketTimeouts
         {
             get
@@ -384,7 +384,7 @@ namespace BrainCloud.Internal
         }
 
         // Json Serialization
-        private JsonWriterSettings _writerSettings = new(); // Used to adjust settings such as maxdepth while serializing. A new JsonWriterSettings does not need to be created everytime we serialize.
+        private JsonWriterSettings _writerSettings = new JsonWriterSettings(); // Used to adjust settings such as maxdepth while serializing. A new JsonWriterSettings does not need to be created everytime we serialize.
         private StringBuilder _stringBuilderOutput;         // String builder necessary for writing serialized json to a string. Unity complains when this is instantiated at compilation.
         private readonly string JSON_ERROR_MESSAGE = "You have exceeded the max json depth, increase the MaxDepth using the MaxDepth variable in BrainCloudClient.cs";
 
@@ -1073,8 +1073,8 @@ namespace BrainCloud.Internal
                 operation = string.Empty;
                 responseData = string.Empty;
 
-                int statusCode = JsonParser.GetValue<int>(response, "status") is int code && code > 0 ? code
-                                                                                                      : StatusCodes.BAD_REQUEST;
+                int statusCode = JsonParser.GetValue<int>(response, "status") is int sCode && sCode > 0 ? sCode
+                                                                                                        : StatusCodes.BAD_REQUEST;
 
                 /*
                  * It's important to note here that a user error callback *might* call
@@ -1593,7 +1593,7 @@ namespace BrainCloud.Internal
                     requestState = new RequestState();
 
                     // prepare json data for server
-                    List<object> messageList = new();
+                    List<object> messageList = new List<object>();
                     bool isAuth = false;
 
                     ServerCall scIndex;
@@ -2246,7 +2246,7 @@ namespace BrainCloud.Internal
             byte[] hash = md5.ComputeHash(inputBytes);
 #endif
 
-            StringBuilder sb = new();
+            StringBuilder sb = new StringBuilder();
             for (int i = 0; i < hash.Length; i++)
             {
                 sb.Append(hash[i].ToString("X2"));
@@ -2605,7 +2605,7 @@ namespace BrainCloud.Internal
 
         public bool IsEmpty => packetId == EMPTY_RESPONSE_BUNDLE;
 
-        public static JsonResponseBundleV2 CreateEmpty() => new(EMPTY_RESPONSE_BUNDLE);
+        public static JsonResponseBundleV2 CreateEmpty() => new JsonResponseBundleV2(EMPTY_RESPONSE_BUNDLE);
 
         public static string GetErrorJson(int status, int reason_code, string status_message)
             => JsonParser.GetJsonErrorMessage(status, reason_code, status_message);
@@ -2657,7 +2657,7 @@ namespace BrainCloud.Common
             bool splitToResponses = false;
             bool skipValue = false;
 
-            sbHelper.Clear();
+            SBHelper.Clear();
 
             for (int i = 1; i < jsonData.Length; i++)
             {
@@ -2668,14 +2668,14 @@ namespace BrainCloud.Common
                     insideProperty = !insideProperty;
                     if (insideProperty)
                     {
-                        sbHelper.Clear();
+                        SBHelper.Clear();
                     }
                 }
                 else if (insideProperty)
                 {
-                    sbHelper.Append(current);
+                    SBHelper.Append(current);
                 }
-                else if (!insideProperty && sbHelper.Length > 0)
+                else if (!insideProperty && SBHelper.Length > 0)
                 {
                     if (skipValue)
                     {
@@ -2683,20 +2683,20 @@ namespace BrainCloud.Common
                     }
                     else
                     {
-                        switch (sbHelper.ToString())
+                        switch (SBHelper.ToString())
                         {
                             case "packetId":
-                                sbHelper.Clear();
+                                SBHelper.Clear();
                                 while (jsonData[i + 1] != ',')
                                 {
                                     current = jsonData[++i];
-                                    sbHelper.Append(current);
+                                    SBHelper.Append(current);
                                 }
-                                packetId = sbHelper.ToString().Trim();
+                                packetId = SBHelper.ToString().Trim();
                                 break;
                             case "responses":
                                 splitToResponses = true;
-                                splitArrays.Clear();
+                                SplitArrays.Clear();
                                 break;
                             case "events":
                                 splitToResponses = false;
@@ -2719,7 +2719,7 @@ namespace BrainCloud.Common
                         }
                     }
 
-                    sbHelper.Clear();
+                    SBHelper.Clear();
                 }
                 else if (current == '{' || current == '[')
                 {
@@ -2743,7 +2743,7 @@ namespace BrainCloud.Common
                                     int len = i - start;
                                     if (len > 0)
                                     {
-                                        splitArrays.Add(jsonData.Substring(start, len).Trim());
+                                        SplitArrays.Add(jsonData.Substring(start, len).Trim());
                                     }
                                 }
                                 goto default;
@@ -2751,7 +2751,7 @@ namespace BrainCloud.Common
                                 if (level == 1 && splitToResponses)
                                 {
                                     int len = i - start;
-                                    splitArrays.Add(jsonData.Substring(start, len).Trim());
+                                    SplitArrays.Add(jsonData.Substring(start, len).Trim());
                                     start = i + 1;
                                     continue;
                                 }
@@ -2762,7 +2762,7 @@ namespace BrainCloud.Common
                                     while (i < jsonData.Length)
                                     {
                                         current = jsonData[i];
-                                        sbHelper.Append(current);
+                                        SBHelper.Append(current);
 
                                         if (jsonData[++i] == '"' && current != '\\')
                                         {
@@ -2777,7 +2777,7 @@ namespace BrainCloud.Common
                             default:
                                 if (level != 0)
                                 {
-                                    sbHelper.Append(current);
+                                    SBHelper.Append(current);
                                 }
                                 continue;
                         }
@@ -2789,32 +2789,32 @@ namespace BrainCloud.Common
                     }
                     else if (splitToResponses)
                     {
-                        responses = splitArrays.Count > 0 ? splitArrays.ToArray() : null;
+                        responses = SplitArrays.Count > 0 ? SplitArrays.ToArray() : null;
                     }
                     else
                     {
-                        events = sbHelper.ToString();
+                        events = SBHelper.ToString();
                     }
 
-                    sbHelper.Clear();
+                    SBHelper.Clear();
                 }
             }
         }
 
         internal static string GetJsonResponseErrorBundleV2(long packetId, string[] responses)
         {
-            sbHelper.Clear();
+            SBHelper.Clear();
 
             for (int i = 0; i < responses.Length;)
             {
-                sbHelper.Append(responses[i]);
+                SBHelper.Append(responses[i]);
                 if (++i < responses.Length)
                 {
-                    sbHelper.Append(',');
+                    SBHelper.Append(',');
                 }
             }
 
-            return $"{{\"packetId\":{packetId},\"responses\":[{sbHelper}]}}";
+            return $"{{\"packetId\":{packetId},\"responses\":[{SBHelper}]}}";
         }
 
         internal static string GetJsonErrorMessage(int status, int reason_code, string status_message)

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/OperationParam.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/OperationParam.cs
@@ -5,167 +5,166 @@
 
 namespace BrainCloud
 {
-    public readonly struct OperationParam : System.IEquatable<OperationParam>, System.IComparable<OperationParam>
+    public readonly struct OperationParam : System.IEquatable<OperationParam>, System.IComparable, System.IComparable<OperationParam>
     {
         #region brainCloud Operation Parameters
 
         //Push Notification Service - Register Params
-        public static readonly OperationParam PushNotificationRegisterParamDeviceType = new("deviceType");
-        public static readonly OperationParam PushNotificationRegisterParamDeviceToken = new("deviceToken");
+        public static readonly OperationParam PushNotificationRegisterParamDeviceType = new OperationParam("deviceType");
+        public static readonly OperationParam PushNotificationRegisterParamDeviceToken = new OperationParam("deviceToken");
 
         //Push Notification Service - Send Params
-        public static readonly OperationParam PushNotificationSendParamToPlayerId = new("toPlayerId");
-        public static readonly OperationParam PushNotificationSendParamProfileId = new("profileId");
-        public static readonly OperationParam PushNotificationSendParamMessage = new("message");
-        public static readonly OperationParam PushNotificationSendParamNotificationTemplateId = new("notificationTemplateId");
-        public static readonly OperationParam PushNotificationSendParamSubstitutions = new("substitutions");
-        public static readonly OperationParam PushNotificationSendParamProfileIds = new("profileIds");
+        public static readonly OperationParam PushNotificationSendParamToPlayerId = new OperationParam("toPlayerId");
+        public static readonly OperationParam PushNotificationSendParamProfileId = new OperationParam("profileId");
+        public static readonly OperationParam PushNotificationSendParamMessage = new OperationParam("message");
+        public static readonly OperationParam PushNotificationSendParamNotificationTemplateId = new OperationParam("notificationTemplateId");
+        public static readonly OperationParam PushNotificationSendParamSubstitutions = new OperationParam("substitutions");
+        public static readonly OperationParam PushNotificationSendParamProfileIds = new OperationParam("profileIds");
 
-        public static readonly OperationParam PushNotificationSendParamFcmContent = new("fcmContent");
-        public static readonly OperationParam PushNotificationSendParamIosContent = new("iosContent");
-        public static readonly OperationParam PushNotificationSendParamFacebookContent = new("facebookContent");
+        public static readonly OperationParam PushNotificationSendParamFcmContent = new OperationParam("fcmContent");
+        public static readonly OperationParam PushNotificationSendParamIosContent = new OperationParam("iosContent");
+        public static readonly OperationParam PushNotificationSendParamFacebookContent = new OperationParam("facebookContent");
 
 
-        public static readonly OperationParam AlertContent = new("alertContent");
-        public static readonly OperationParam CustomData = new("customData");
+        public static readonly OperationParam AlertContent = new OperationParam("alertContent");
+        public static readonly OperationParam CustomData = new OperationParam("customData");
 
-        public static readonly OperationParam StartDateUTC = new("startDateUTC");
-        public static readonly OperationParam MinutesFromNow = new("minutesFromNow");
+        public static readonly OperationParam StartDateUTC = new OperationParam("startDateUTC");
+        public static readonly OperationParam MinutesFromNow = new OperationParam("minutesFromNow");
 
         // Twitter Service - Verify Params
-        public static readonly OperationParam TwitterServiceVerifyToken = new("token");
-        public static readonly OperationParam TwitterServiceVerifyVerifier = new("verifier");
+        public static readonly OperationParam TwitterServiceVerifyToken = new OperationParam("token");
+        public static readonly OperationParam TwitterServiceVerifyVerifier = new OperationParam("verifier");
 
         // Twitter Service - Tweet Params
-        public static readonly OperationParam TwitterServiceTweetToken = new("token");
-        public static readonly OperationParam TwitterServiceTweetSecret = new("secret");
-        public static readonly OperationParam TwitterServiceTweetTweet = new("tweet");
-        public static readonly OperationParam TwitterServiceTweetPic = new("pic");
+        public static readonly OperationParam TwitterServiceTweetToken = new OperationParam("token");
+        public static readonly OperationParam TwitterServiceTweetSecret = new OperationParam("secret");
+        public static readonly OperationParam TwitterServiceTweetTweet = new OperationParam("tweet");
+        public static readonly OperationParam TwitterServiceTweetPic = new OperationParam("pic");
 
-        public static readonly OperationParam BlockChainConfig = new("blockchainConfig");
-        public static readonly OperationParam BlockChainIntegrationId = new("integrationId");
-        public static readonly OperationParam BlockChainContext = new("contextJson");
-        public static readonly OperationParam PublicKey = new("publicKey");
-
-        // Authenticate Service - Authenticate Params
-        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationType = new("authenticationType");
-        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationToken = new("authenticationToken");
-        public static readonly OperationParam AuthenticateServiceAuthenticateExternalId = new("externalId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateUniversalId = new("universalId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateGameId = new("gameId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateDeviceId = new("deviceId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateForceMergeFlag = new("forceMergeFlag");
-        public static readonly OperationParam AuthenticateServiceAuthenticateReleasePlatform = new("releasePlatform");
-        public static readonly OperationParam AuthenticateServiceAuthenticateGameVersion = new("gameVersion");
-        public static readonly OperationParam AuthenticateServiceAuthenticateBrainCloudVersion = new("clientLibVersion");
-        public static readonly OperationParam AuthenticateServiceAuthenticateExternalAuthName = new("externalAuthName");
-        public static readonly OperationParam AuthenticateServiceAuthenticateEmailAddress = new("emailAddress");
-        public static readonly OperationParam AuthenticateServiceAuthenticateServiceParams = new("serviceParams");
-        public static readonly OperationParam AuthenticateServiceAuthenticateTokenTtlInMinutes = new("tokenTtlInMinutes");
-
-        public static readonly OperationParam AuthenticateServiceAuthenticateLevelName = new("levelName");
-        public static readonly OperationParam AuthenticateServiceAuthenticatePeerCode = new("peerCode");
-
-        public static readonly OperationParam AuthenticateServiceAuthenticateCountryCode = new("countryCode");
-        public static readonly OperationParam AuthenticateServiceAuthenticateLanguageCode = new("languageCode");
-        public static readonly OperationParam AuthenticateServiceAuthenticateTimeZoneOffset = new("timeZoneOffset");
-
-        public static readonly OperationParam AuthenticateServiceAuthenticateAuthUpgradeID = new("upgradeAppId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateAnonymousId = new("anonymousId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateProfileId = new("profileId");
-        public static readonly OperationParam AuthenticateServiceAuthenticateForceCreate = new("forceCreate");
-        public static readonly OperationParam AuthenticateServiceAuthenticateCompressResponses = new("compressResponses");
-        public static readonly OperationParam AuthenticateServicePlayerSessionExpiry = new("playerSessionExpiry");
-        public static readonly OperationParam AuthenticateServiceAuthenticateExtraJson = new("extraJson");
+        public static readonly OperationParam BlockChainConfig = new OperationParam("blockchainConfig");
+        public static readonly OperationParam BlockChainIntegrationId = new OperationParam("integrationId");
+        public static readonly OperationParam BlockChainContext = new OperationParam("contextJson");
+        public static readonly OperationParam PublicKey = new OperationParam("publicKey");
 
         // Authenticate Service - Authenticate Params
-        public static readonly OperationParam IdentityServiceExternalId = new("externalId");
-        public static readonly OperationParam IdentityServiceAuthenticationType = new("authenticationType");
-        public static readonly OperationParam IdentityServiceExternalAuthName = new("externalAuthName");
-        public static readonly OperationParam IdentityServiceContinueAnon = new("continueAnon");
-        public static readonly OperationParam IdentityServiceOldEmailAddress = new("oldEmailAddress");
-        public static readonly OperationParam IdentityServiceNewEmailAddress = new("newEmailAddress");
-        public static readonly OperationParam IdentityServiceUpdateContactEmail = new("updateContactEmail");
+        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationType = new OperationParam("authenticationType");
+        public static readonly OperationParam AuthenticateServiceAuthenticateAuthenticationToken = new OperationParam("authenticationToken");
+        public static readonly OperationParam AuthenticateServiceAuthenticateExternalId = new OperationParam("externalId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateUniversalId = new OperationParam("universalId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateGameId = new OperationParam("gameId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateDeviceId = new OperationParam("deviceId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateForceMergeFlag = new OperationParam("forceMergeFlag");
+        public static readonly OperationParam AuthenticateServiceAuthenticateReleasePlatform = new OperationParam("releasePlatform");
+        public static readonly OperationParam AuthenticateServiceAuthenticateGameVersion = new OperationParam("gameVersion");
+        public static readonly OperationParam AuthenticateServiceAuthenticateBrainCloudVersion = new OperationParam("clientLibVersion");
+        public static readonly OperationParam AuthenticateServiceAuthenticateExternalAuthName = new OperationParam("externalAuthName");
+        public static readonly OperationParam AuthenticateServiceAuthenticateEmailAddress = new OperationParam("emailAddress");
+        public static readonly OperationParam AuthenticateServiceAuthenticateServiceParams = new OperationParam("serviceParams");
+        public static readonly OperationParam AuthenticateServiceAuthenticateTokenTtlInMinutes = new OperationParam("tokenTtlInMinutes");
 
+        public static readonly OperationParam AuthenticateServiceAuthenticateLevelName = new OperationParam("levelName");
+        public static readonly OperationParam AuthenticateServiceAuthenticatePeerCode = new OperationParam("peerCode");
+
+        public static readonly OperationParam AuthenticateServiceAuthenticateCountryCode = new OperationParam("countryCode");
+        public static readonly OperationParam AuthenticateServiceAuthenticateLanguageCode = new OperationParam("languageCode");
+        public static readonly OperationParam AuthenticateServiceAuthenticateTimeZoneOffset = new OperationParam("timeZoneOffset");
+
+        public static readonly OperationParam AuthenticateServiceAuthenticateAuthUpgradeID = new OperationParam("upgradeAppId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateAnonymousId = new OperationParam("anonymousId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateProfileId = new OperationParam("profileId");
+        public static readonly OperationParam AuthenticateServiceAuthenticateForceCreate = new OperationParam("forceCreate");
+        public static readonly OperationParam AuthenticateServiceAuthenticateCompressResponses = new OperationParam("compressResponses");
+        public static readonly OperationParam AuthenticateServicePlayerSessionExpiry = new OperationParam("playerSessionExpiry");
+        public static readonly OperationParam AuthenticateServiceAuthenticateExtraJson = new OperationParam("extraJson");
+
+        // Authenticate Service - Authenticate Params
+        public static readonly OperationParam IdentityServiceExternalId = new OperationParam("externalId");
+        public static readonly OperationParam IdentityServiceAuthenticationType = new OperationParam("authenticationType");
+        public static readonly OperationParam IdentityServiceExternalAuthName = new OperationParam("externalAuthName");
+        public static readonly OperationParam IdentityServiceContinueAnon = new OperationParam("continueAnon");
+        public static readonly OperationParam IdentityServiceOldEmailAddress = new OperationParam("oldEmailAddress");
+        public static readonly OperationParam IdentityServiceNewEmailAddress = new OperationParam("newEmailAddress");
+        public static readonly OperationParam IdentityServiceUpdateContactEmail = new OperationParam("updateContactEmail");
 
         // Peer
-        public static readonly OperationParam Peer = new("peer");
+        public static readonly OperationParam Peer = new OperationParam("peer");
 
         // Entity Service 
-        public static readonly OperationParam EntityServiceEntityId = new("entityId");
-        public static readonly OperationParam EntityServiceEntityType = new("entityType");
-        public static readonly OperationParam EntityServiceEntitySubtype = new("entitySubtype");
-        public static readonly OperationParam EntityServiceData = new("data");
-        public static readonly OperationParam EntityServiceAcl = new("acl");
-        public static readonly OperationParam EntityServiceFriendData = new("friendData");
-        public static readonly OperationParam EntityServiceVersion = new("version");
-        public static readonly OperationParam EntityServiceUpdateOps = new("updateOps");
-        public static readonly OperationParam EntityServiceTargetPlayerId = new("targetPlayerId");
+        public static readonly OperationParam EntityServiceEntityId = new OperationParam("entityId");
+        public static readonly OperationParam EntityServiceEntityType = new OperationParam("entityType");
+        public static readonly OperationParam EntityServiceEntitySubtype = new OperationParam("entitySubtype");
+        public static readonly OperationParam EntityServiceData = new OperationParam("data");
+        public static readonly OperationParam EntityServiceAcl = new OperationParam("acl");
+        public static readonly OperationParam EntityServiceFriendData = new OperationParam("friendData");
+        public static readonly OperationParam EntityServiceVersion = new OperationParam("version");
+        public static readonly OperationParam EntityServiceUpdateOps = new OperationParam("updateOps");
+        public static readonly OperationParam EntityServiceTargetPlayerId = new OperationParam("targetPlayerId");
 
         // Global Entity Service - Params
-        public static readonly OperationParam GlobalEntityServiceEntityId = new("entityId");
-        public static readonly OperationParam GlobalEntityServiceEntityType = new("entityType");
-        public static readonly OperationParam GlobalEntityServiceIndexedId = new("entityIndexedId");
-        public static readonly OperationParam GlobalEntityServiceTimeToLive = new("timeToLive");
-        public static readonly OperationParam GlobalEntityServiceData = new("data");
-        public static readonly OperationParam GlobalEntityServiceAcl = new("acl");
-        public static readonly OperationParam GlobalEntityServiceVersion = new("version");
-        public static readonly OperationParam GlobalEntityServiceMaxReturn = new("maxReturn");
-        public static readonly OperationParam GlobalEntityServiceWhere = new("where");
-        public static readonly OperationParam GlobalEntityServiceOrderBy = new("orderBy");
-        public static readonly OperationParam GlobalEntityServiceContext = new("context");
-        public static readonly OperationParam GlobalEntityServicePageOffset = new("pageOffset");
-        public static readonly OperationParam OwnerId = new("ownerId");
+        public static readonly OperationParam GlobalEntityServiceEntityId = new OperationParam("entityId");
+        public static readonly OperationParam GlobalEntityServiceEntityType = new OperationParam("entityType");
+        public static readonly OperationParam GlobalEntityServiceIndexedId = new OperationParam("entityIndexedId");
+        public static readonly OperationParam GlobalEntityServiceTimeToLive = new OperationParam("timeToLive");
+        public static readonly OperationParam GlobalEntityServiceData = new OperationParam("data");
+        public static readonly OperationParam GlobalEntityServiceAcl = new OperationParam("acl");
+        public static readonly OperationParam GlobalEntityServiceVersion = new OperationParam("version");
+        public static readonly OperationParam GlobalEntityServiceMaxReturn = new OperationParam("maxReturn");
+        public static readonly OperationParam GlobalEntityServiceWhere = new OperationParam("where");
+        public static readonly OperationParam GlobalEntityServiceOrderBy = new OperationParam("orderBy");
+        public static readonly OperationParam GlobalEntityServiceContext = new OperationParam("context");
+        public static readonly OperationParam GlobalEntityServicePageOffset = new OperationParam("pageOffset");
+        public static readonly OperationParam OwnerId = new OperationParam("ownerId");
 
         // Event Service - Send Params
-        public static readonly OperationParam EventServiceSendToId = new("toId");
-        public static readonly OperationParam EventServiceSendToIds = new("toIds");
-        public static readonly OperationParam EventServiceSendEventType = new("eventType");
-        public static readonly OperationParam EventServiceSendEventId = new("eventId");
-        public static readonly OperationParam EventServiceSendEventData = new("eventData");
-        public static readonly OperationParam EventServiceSendRecordLocally = new("recordLocally");
+        public static readonly OperationParam EventServiceSendToId = new OperationParam("toId");
+        public static readonly OperationParam EventServiceSendToIds = new OperationParam("toIds");
+        public static readonly OperationParam EventServiceSendEventType = new OperationParam("eventType");
+        public static readonly OperationParam EventServiceSendEventId = new OperationParam("eventId");
+        public static readonly OperationParam EventServiceSendEventData = new OperationParam("eventData");
+        public static readonly OperationParam EventServiceSendRecordLocally = new OperationParam("recordLocally");
 
         // Event Service - Update Event Data Params
-        public static readonly OperationParam EventServiceUpdateEventDataFromId = new("fromId");
-        public static readonly OperationParam EventServiceUpdateEventDataEventId = new("eventId");
-        public static readonly OperationParam EventServiceUpdateEventDataData = new("eventData");
-        public static readonly OperationParam EvId = new("evId");
-        public static readonly OperationParam EventServiceEvIds  = new("evIds");
-        public static readonly OperationParam EventServiceDateMillis  = new("dateMillis");
-        public static readonly OperationParam EventServiceEventType   = new("eventType");
+        public static readonly OperationParam EventServiceUpdateEventDataFromId = new OperationParam("fromId");
+        public static readonly OperationParam EventServiceUpdateEventDataEventId = new OperationParam("eventId");
+        public static readonly OperationParam EventServiceUpdateEventDataData = new OperationParam("eventData");
+        public static readonly OperationParam EvId = new OperationParam("evId");
+        public static readonly OperationParam EventServiceEvIds  = new OperationParam("evIds");
+        public static readonly OperationParam EventServiceDateMillis  = new OperationParam("dateMillis");
+        public static readonly OperationParam EventServiceEventType   = new OperationParam("eventType");
         
         // Event Service - Delete Incoming Params
-        public static readonly OperationParam EventServiceDeleteIncomingEventId = new("eventId");
-        public static readonly OperationParam EventServiceDeleteIncomingFromId = new("fromId");
+        public static readonly OperationParam EventServiceDeleteIncomingEventId = new OperationParam("eventId");
+        public static readonly OperationParam EventServiceDeleteIncomingFromId = new OperationParam("fromId");
 
         // Event Service - Delete Sent Params
-        public static readonly OperationParam EventServiceDeleteSentEventId = new("eventId");
-        public static readonly OperationParam EventServiceDeleteSentToId = new("toId");
-        public static readonly OperationParam EventServiceIncludeIncomingEvents = new("includeIncomingEvents");
-        public static readonly OperationParam EventServiceIncludeSentEvents = new("includeSentEvents");
+        public static readonly OperationParam EventServiceDeleteSentEventId = new OperationParam("eventId");
+        public static readonly OperationParam EventServiceDeleteSentToId = new OperationParam("toId");
+        public static readonly OperationParam EventServiceIncludeIncomingEvents = new OperationParam("includeIncomingEvents");
+        public static readonly OperationParam EventServiceIncludeSentEvents = new OperationParam("includeSentEvents");
 
         // Friend Service - Params
-        public static readonly OperationParam FriendServiceEntityId = new("entityId");
-        public static readonly OperationParam FriendServiceExternalId = new("externalId");
-        public static readonly OperationParam FriendServiceExternalIds = new("externalIds");
-        public static readonly OperationParam FriendServiceProfileId = new("profileId");
-        public static readonly OperationParam FriendServiceFriendId = new("friendId");
-        public static readonly OperationParam FriendServiceAuthenticationType = new("authenticationType");
-        public static readonly OperationParam ExternalAuthType = new("externalAuthType");
-        public static readonly OperationParam FriendServiceEntityType = new("entityType");
-        public static readonly OperationParam FriendServiceEntitySubtype = new("entitySubtype");
-        public static readonly OperationParam FriendServiceIncludeSummaryData = new("includeSummaryData");
-        public static readonly OperationParam FriendServiceFriendPlatform = new("friendPlatform");
-        public static readonly OperationParam FriendServiceProfileIds = new("profileIds");
-        public static readonly OperationParam FriendServiceMode = new("mode");
+        public static readonly OperationParam FriendServiceEntityId = new OperationParam("entityId");
+        public static readonly OperationParam FriendServiceExternalId = new OperationParam("externalId");
+        public static readonly OperationParam FriendServiceExternalIds = new OperationParam("externalIds");
+        public static readonly OperationParam FriendServiceProfileId = new OperationParam("profileId");
+        public static readonly OperationParam FriendServiceFriendId = new OperationParam("friendId");
+        public static readonly OperationParam FriendServiceAuthenticationType = new OperationParam("authenticationType");
+        public static readonly OperationParam ExternalAuthType = new OperationParam("externalAuthType");
+        public static readonly OperationParam FriendServiceEntityType = new OperationParam("entityType");
+        public static readonly OperationParam FriendServiceEntitySubtype = new OperationParam("entitySubtype");
+        public static readonly OperationParam FriendServiceIncludeSummaryData = new OperationParam("includeSummaryData");
+        public static readonly OperationParam FriendServiceFriendPlatform = new OperationParam("friendPlatform");
+        public static readonly OperationParam FriendServiceProfileIds = new OperationParam("profileIds");
+        public static readonly OperationParam FriendServiceMode = new OperationParam("mode");
 
         // Friend Service operations
         //public static readonly Operation FriendServiceReadFriends = new Operation("READ_FRIENDS");
 
         // Friend Service - Read Player State Params
-        public static readonly OperationParam FriendServiceReadPlayerStateFriendId = new("friendId");
-        public static readonly OperationParam FriendServiceSearchText = new("searchText");
-        public static readonly OperationParam FriendServiceMaxResults = new("maxResults");
+        public static readonly OperationParam FriendServiceReadPlayerStateFriendId = new OperationParam("friendId");
+        public static readonly OperationParam FriendServiceSearchText = new OperationParam("searchText");
+        public static readonly OperationParam FriendServiceMaxResults = new OperationParam("maxResults");
 
 
         // Friend Data Service - Read Friends Params (C++ only?)
@@ -174,66 +173,66 @@ namespace BrainCloud
         //friendIdCount;
 
         //Achievements Event Data Params
-        public static readonly OperationParam GamificationServiceAchievementsName = new("achievements");
-        public static readonly OperationParam GamificationServiceAchievementsData = new("data");
-        public static readonly OperationParam GamificationServiceAchievementsGranted = new("achievementsGranted");
-        public static readonly OperationParam GamificationServiceCategory = new("category");
-        public static readonly OperationParam GamificationServiceMilestones = new("milestones");
-        public static readonly OperationParam GamificationServiceIncludeMetaData = new("includeMetaData");
+        public static readonly OperationParam GamificationServiceAchievementsName = new OperationParam("achievements");
+        public static readonly OperationParam GamificationServiceAchievementsData = new OperationParam("data");
+        public static readonly OperationParam GamificationServiceAchievementsGranted = new OperationParam("achievementsGranted");
+        public static readonly OperationParam GamificationServiceCategory = new OperationParam("category");
+        public static readonly OperationParam GamificationServiceMilestones = new OperationParam("milestones");
+        public static readonly OperationParam GamificationServiceIncludeMetaData = new OperationParam("includeMetaData");
 
         // Player Statistic Event Params
-        public static readonly OperationParam PlayerStatisticEventServiceEventName = new("eventName");
-        public static readonly OperationParam PlayerStatisticEventServiceEventMultiplier = new("eventMultiplier");
-        public static readonly OperationParam PlayerStatisticEventServiceEvents = new("events");
+        public static readonly OperationParam PlayerStatisticEventServiceEventName = new OperationParam("eventName");
+        public static readonly OperationParam PlayerStatisticEventServiceEventMultiplier = new OperationParam("eventMultiplier");
+        public static readonly OperationParam PlayerStatisticEventServiceEvents = new OperationParam("events");
 
         // Presence Params
-        public static readonly OperationParam PresenceServicePlatform = new("platform");
-        public static readonly OperationParam PresenceServiceIncludeOffline = new("includeOffline");
-        public static readonly OperationParam PresenceServiceGroupId = new("groupId");
-        public static readonly OperationParam PresenceServiceProfileIds = new("profileIds");
-        public static readonly OperationParam PresenceServiceBidirectional = new("bidirectional");
-        public static readonly OperationParam PresenceServiceVisibile = new("visible");
-        public static readonly OperationParam PresenceServiceActivity = new("activity");
+        public static readonly OperationParam PresenceServicePlatform = new OperationParam("platform");
+        public static readonly OperationParam PresenceServiceIncludeOffline = new OperationParam("includeOffline");
+        public static readonly OperationParam PresenceServiceGroupId = new OperationParam("groupId");
+        public static readonly OperationParam PresenceServiceProfileIds = new OperationParam("profileIds");
+        public static readonly OperationParam PresenceServiceBidirectional = new OperationParam("bidirectional");
+        public static readonly OperationParam PresenceServiceVisibile = new OperationParam("visible");
+        public static readonly OperationParam PresenceServiceActivity = new OperationParam("activity");
 
         // Player State Service - Read Params
-        public static readonly OperationParam PlayerStateServiceReadEntitySubtype = new("entitySubType");
+        public static readonly OperationParam PlayerStateServiceReadEntitySubtype = new OperationParam("entitySubType");
 
         // Player State Service - Update Summary Params
-        public static readonly OperationParam PlayerStateServiceUpdateSummaryFriendData = new("summaryFriendData");
-        public static readonly OperationParam PlayerStateServiceUpdateNameData = new("playerName");
-        public static readonly OperationParam PlayerStateServiceTimeZoneOffset = new("timeZoneOffset");
-        public static readonly OperationParam PlayerStateServiceLanguageCode = new("languageCode");
+        public static readonly OperationParam PlayerStateServiceUpdateSummaryFriendData = new OperationParam("summaryFriendData");
+        public static readonly OperationParam PlayerStateServiceUpdateNameData = new OperationParam("playerName");
+        public static readonly OperationParam PlayerStateServiceTimeZoneOffset = new OperationParam("timeZoneOffset");
+        public static readonly OperationParam PlayerStateServiceLanguageCode = new OperationParam("languageCode");
 
         // Player State Service - Atributes
-        public static readonly OperationParam PlayerStateServiceAttributes = new("attributes");
-        public static readonly OperationParam PlayerStateServiceWipeExisting = new("wipeExisting");
+        public static readonly OperationParam PlayerStateServiceAttributes = new OperationParam("attributes");
+        public static readonly OperationParam PlayerStateServiceWipeExisting = new OperationParam("wipeExisting");
 
-        public static readonly OperationParam PlayerStateServiceIncludeSummaryData = new("includePlayerSummaryData");
+        public static readonly OperationParam PlayerStateServiceIncludeSummaryData = new OperationParam("includePlayerSummaryData");
 
         // Player State Service - UPDATE_PICTURE_URL
-        public static readonly OperationParam PlayerStateServicePlayerPictureUrl = new("playerPictureUrl");
-        public static readonly OperationParam PlayerStateServiceContactEmail = new("contactEmail");
+        public static readonly OperationParam PlayerStateServicePlayerPictureUrl = new OperationParam("playerPictureUrl");
+        public static readonly OperationParam PlayerStateServiceContactEmail = new OperationParam("contactEmail");
 
         // Player State Service - Reset Params
         //public static readonly Operation PlayerStateServiceReset = new Operation("");
         
 
         // Player Statistics Service - Update Increment Params
-        public static readonly OperationParam PlayerStatisticsServiceStats = new("statistics");
-        public static readonly OperationParam PlayerStatisticsServiceStatNames = new("statNames");
-        public static readonly OperationParam PlayerStatisticsExperiencePoints = new("xp_points");
+        public static readonly OperationParam PlayerStatisticsServiceStats = new OperationParam("statistics");
+        public static readonly OperationParam PlayerStatisticsServiceStatNames = new OperationParam("statNames");
+        public static readonly OperationParam PlayerStatisticsExperiencePoints = new OperationParam("xp_points");
 
         // Player Statistics Service - Status Param
-        public static readonly OperationParam PlayerStateServiceStatusName = new("statusName");
+        public static readonly OperationParam PlayerStateServiceStatusName = new OperationParam("statusName");
         
         // Player Statistics Service - Extend User Status Params
-        public static readonly OperationParam PlayerStateServiceAdditionalSecs = new("additionalSecs");
-        public static readonly OperationParam PlayerStateServiceDetails = new("details");
+        public static readonly OperationParam PlayerStateServiceAdditionalSecs = new OperationParam("additionalSecs");
+        public static readonly OperationParam PlayerStateServiceDetails = new OperationParam("details");
 
-        public static readonly OperationParam PlayerStateServiceDurationSecs = new("durationSecs");
+        public static readonly OperationParam PlayerStateServiceDurationSecs = new OperationParam("durationSecs");
 
         // Player Statistics Service - Read Params
-        public static readonly OperationParam PlayerStatisticsServiceReadEntitySubType = new("entitySubType");
+        public static readonly OperationParam PlayerStatisticsServiceReadEntitySubType = new OperationParam("entitySubType");
 
         //public static readonly Operation PlayerStatisticsServiceDelete = new Operation("DELETE");
 
@@ -242,359 +241,359 @@ namespace BrainCloud
         //public static readonly Operation PushNotificationServiceRegister = new Operation("REGISTER");
 
         // Social Leaderboard Service - general parameters
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardId = new("leaderboardId");
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardIds = new("leaderboardIds");
-        public static readonly OperationParam SocialLeaderboardServiceReplaceName = new("replaceName");
-        public static readonly OperationParam SocialLeaderboardServiceScore = new("score");
-        public static readonly OperationParam SocialLeaderboardServiceScoreData = new("scoreData");
-        public static readonly OperationParam SocialLeaderboardServiceConfigJson = new("configJson");
-        public static readonly OperationParam SocialLeaderboardServiceData = new("data");
-        public static readonly OperationParam SocialLeaderboardServiceEventName = new("eventName");
-        public static readonly OperationParam SocialLeaderboardServiceEventMultiplier = new("eventMultiplier");
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardType = new("leaderboardType");
-        public static readonly OperationParam SocialLeaderboardServiceRotationType = new("rotationType");
-        public static readonly OperationParam SocialLeaderboardServiceRotationReset = new("rotationReset");
-        public static readonly OperationParam SocialLeaderboardServiceRetainedCount = new("retainedCount");
-        public static readonly OperationParam NumDaysToRotate = new("numDaysToRotate");
-        public static readonly OperationParam SocialLeaderboardServiceFetchType = new("fetchType");
-        public static readonly OperationParam SocialLeaderboardServiceMaxResults = new("maxResults");
-        public static readonly OperationParam SocialLeaderboardServiceSort = new("sort");
-        public static readonly OperationParam SocialLeaderboardServiceStartIndex = new("startIndex");
-        public static readonly OperationParam SocialLeaderboardServiceEndIndex = new("endIndex");
-        public static readonly OperationParam SocialLeaderboardServiceBeforeCount = new("beforeCount");
-        public static readonly OperationParam SocialLeaderboardServiceAfterCount = new("afterCount");
-        public static readonly OperationParam SocialLeaderboardServiceIncludeLeaderboardSize = new("includeLeaderboardSize");
-        public static readonly OperationParam SocialLeaderboardServiceVersionId = new("versionId");
-        public static readonly OperationParam SocialLeaderboardServiceLeaderboardResultCount = new("leaderboardResultCount");
-        public static readonly OperationParam SocialLeaderboardServiceGroupId = new("groupId");
-        public static readonly OperationParam SocialLeaderboardServiceProfileIds = new("profileIds");
-        public static readonly OperationParam SocialLeaderboardServiceRotationResetTime = new("rotationResetTime");
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardId = new OperationParam("leaderboardId");
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardIds = new OperationParam("leaderboardIds");
+        public static readonly OperationParam SocialLeaderboardServiceReplaceName = new OperationParam("replaceName");
+        public static readonly OperationParam SocialLeaderboardServiceScore = new OperationParam("score");
+        public static readonly OperationParam SocialLeaderboardServiceScoreData = new OperationParam("scoreData");
+        public static readonly OperationParam SocialLeaderboardServiceConfigJson = new OperationParam("configJson");
+        public static readonly OperationParam SocialLeaderboardServiceData = new OperationParam("data");
+        public static readonly OperationParam SocialLeaderboardServiceEventName = new OperationParam("eventName");
+        public static readonly OperationParam SocialLeaderboardServiceEventMultiplier = new OperationParam("eventMultiplier");
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardType = new OperationParam("leaderboardType");
+        public static readonly OperationParam SocialLeaderboardServiceRotationType = new OperationParam("rotationType");
+        public static readonly OperationParam SocialLeaderboardServiceRotationReset = new OperationParam("rotationReset");
+        public static readonly OperationParam SocialLeaderboardServiceRetainedCount = new OperationParam("retainedCount");
+        public static readonly OperationParam NumDaysToRotate = new OperationParam("numDaysToRotate");
+        public static readonly OperationParam SocialLeaderboardServiceFetchType = new OperationParam("fetchType");
+        public static readonly OperationParam SocialLeaderboardServiceMaxResults = new OperationParam("maxResults");
+        public static readonly OperationParam SocialLeaderboardServiceSort = new OperationParam("sort");
+        public static readonly OperationParam SocialLeaderboardServiceStartIndex = new OperationParam("startIndex");
+        public static readonly OperationParam SocialLeaderboardServiceEndIndex = new OperationParam("endIndex");
+        public static readonly OperationParam SocialLeaderboardServiceBeforeCount = new OperationParam("beforeCount");
+        public static readonly OperationParam SocialLeaderboardServiceAfterCount = new OperationParam("afterCount");
+        public static readonly OperationParam SocialLeaderboardServiceIncludeLeaderboardSize = new OperationParam("includeLeaderboardSize");
+        public static readonly OperationParam SocialLeaderboardServiceVersionId = new OperationParam("versionId");
+        public static readonly OperationParam SocialLeaderboardServiceLeaderboardResultCount = new OperationParam("leaderboardResultCount");
+        public static readonly OperationParam SocialLeaderboardServiceGroupId = new OperationParam("groupId");
+        public static readonly OperationParam SocialLeaderboardServiceProfileIds = new OperationParam("profileIds");
+        public static readonly OperationParam SocialLeaderboardServiceRotationResetTime = new OperationParam("rotationResetTime");
 
 
         // Social Leaderboard Service - Reset Score Params
         //public static readonly Operation SocialLeaderboardServiceResetScore = new Operation("");
 
         // Product Service
-        public static readonly OperationParam ProductServiceCurrencyId = new("vc_id");
-        public static readonly OperationParam ProductServiceCurrencyAmount = new("vc_amount");
+        public static readonly OperationParam ProductServiceCurrencyId = new OperationParam("vc_id");
+        public static readonly OperationParam ProductServiceCurrencyAmount = new OperationParam("vc_amount");
 
         // AppStore 
-        public static readonly OperationParam AppStoreServiceStoreId = new("storeId");
-        public static readonly OperationParam AppStoreServiceIAPId = new("iapId");
-        public static readonly OperationParam AppStoreServiceReceiptData = new("receiptData");
-        public static readonly OperationParam AppStoreServicePurchaseData = new("purchaseData");
-        public static readonly OperationParam AppStoreServiceTransactionId = new("transactionId");
-        public static readonly OperationParam AppStoreServiceTransactionData = new("transactionData");
-        public static readonly OperationParam AppStoreServicePriceInfoCriteria = new("priceInfoCriteria");
-        public static readonly OperationParam AppStoreServiceUserCurrency = new("userCurrency");
-        public static readonly OperationParam AppStoreServiceCategory = new("category");
-        public static readonly OperationParam AppStoreServicePayload = new("payload");
+        public static readonly OperationParam AppStoreServiceStoreId = new OperationParam("storeId");
+        public static readonly OperationParam AppStoreServiceIAPId = new OperationParam("iapId");
+        public static readonly OperationParam AppStoreServiceReceiptData = new OperationParam("receiptData");
+        public static readonly OperationParam AppStoreServicePurchaseData = new OperationParam("purchaseData");
+        public static readonly OperationParam AppStoreServiceTransactionId = new OperationParam("transactionId");
+        public static readonly OperationParam AppStoreServiceTransactionData = new OperationParam("transactionData");
+        public static readonly OperationParam AppStoreServicePriceInfoCriteria = new OperationParam("priceInfoCriteria");
+        public static readonly OperationParam AppStoreServiceUserCurrency = new OperationParam("userCurrency");
+        public static readonly OperationParam AppStoreServiceCategory = new OperationParam("category");
+        public static readonly OperationParam AppStoreServicePayload = new OperationParam("payload");
 
         // Virtual Currency Service
-        public static readonly OperationParam VirtualCurrencyServiceCurrencyId = new("vcId");
-        public static readonly OperationParam VirtualCurrencyServiceCurrencyAmount = new("vcAmount");
+        public static readonly OperationParam VirtualCurrencyServiceCurrencyId = new OperationParam("vcId");
+        public static readonly OperationParam VirtualCurrencyServiceCurrencyAmount = new OperationParam("vcAmount");
 
         // Product Service - Get Inventory Params
-        public static readonly OperationParam ProductServiceGetInventoryPlatform = new("platform");
-        public static readonly OperationParam ProductServiceGetInventoryUserCurrency = new("user_currency");
-        public static readonly OperationParam ProductServiceGetInventoryCategory = new("category");
+        public static readonly OperationParam ProductServiceGetInventoryPlatform = new OperationParam("platform");
+        public static readonly OperationParam ProductServiceGetInventoryUserCurrency = new OperationParam("user_currency");
+        public static readonly OperationParam ProductServiceGetInventoryCategory = new OperationParam("category");
 
         // Product Service - Op Cash In Receipt Params
-        public static readonly OperationParam ProductServiceOpCashInReceiptReceipt = new("receipt"); //C++ only
-        public static readonly OperationParam ProductServiceOpCashInReceiptUrl = new("url"); //C++ only
+        public static readonly OperationParam ProductServiceOpCashInReceiptReceipt = new OperationParam("receipt"); //C++ only
+        public static readonly OperationParam ProductServiceOpCashInReceiptUrl = new OperationParam("url"); //C++ only
 
         // Product Service - Reset Player VC Params
-        //public static readonly OperationParam ProductServiceResetPlayerVC = new("");
+        //public static readonly OperationParam ProductServiceResetPlayerVC = new OperationParam("");
 
         // Heartbeat Service - Params
-        //public static readonly OperationParam HeartbeatService = new("");
+        //public static readonly OperationParam HeartbeatService = new OperationParam("");
 
         // Time Service - Params
-        //public static readonly OperationParam TimeService = new("");
+        //public static readonly OperationParam TimeService = new OperationParam("");
 
         // Server Time Service - Read Params
-        public static readonly OperationParam ServerTimeServiceRead = new("");
+        public static readonly OperationParam ServerTimeServiceRead = new OperationParam("");
 
         // data creation parms
-        public static readonly OperationParam ServiceMessageService = new("service");
-        public static readonly OperationParam ServiceMessageOperation = new("operation");
-        public static readonly OperationParam ServiceMessageData = new("data");
+        public static readonly OperationParam ServiceMessageService = new OperationParam("service");
+        public static readonly OperationParam ServiceMessageOperation = new OperationParam("operation");
+        public static readonly OperationParam ServiceMessageData = new OperationParam("data");
 
         // data bundle creation parms
-        public static readonly OperationParam ServiceMessagePacketId = new("packetId");
-        public static readonly OperationParam ServiceMessageSessionId = new("sessionId");
-        public static readonly OperationParam ServiceMessageGameId = new("gameId");
-        public static readonly OperationParam ServiceMessageMessages = new("messages");
-        public static readonly OperationParam ProfileId = new("profileId");
+        public static readonly OperationParam ServiceMessagePacketId = new OperationParam("packetId");
+        public static readonly OperationParam ServiceMessageSessionId = new OperationParam("sessionId");
+        public static readonly OperationParam ServiceMessageGameId = new OperationParam("gameId");
+        public static readonly OperationParam ServiceMessageMessages = new OperationParam("messages");
+        public static readonly OperationParam ProfileId = new OperationParam("profileId");
 
         // Error Params
-        public static readonly OperationParam ServiceMessageReasonCode = new("reason_code");
-        public static readonly OperationParam ServiceMessageStatusMessage = new("status_message");
+        public static readonly OperationParam ServiceMessageReasonCode = new OperationParam("reason_code");
+        public static readonly OperationParam ServiceMessageStatusMessage = new OperationParam("status_message");
 
-        public static readonly OperationParam DeviceRegistrationTypeIos = new("IOS");
-        public static readonly OperationParam DeviceRegistrationTypeAndroid = new("ANG");
+        public static readonly OperationParam DeviceRegistrationTypeIos = new OperationParam("IOS");
+        public static readonly OperationParam DeviceRegistrationTypeAndroid = new OperationParam("ANG");
 
-        public static readonly OperationParam ScriptServiceRunScriptName = new("scriptName");
-        public static readonly OperationParam ScriptServiceRunScriptData = new("scriptData");
-        public static readonly OperationParam ScriptServiceStartDateUTC = new("startDateUTC");
-        public static readonly OperationParam ScriptServiceStartMinutesFromNow = new("minutesFromNow");
-        public static readonly OperationParam ScriptServiceParentLevel = new("parentLevel");
-        public static readonly OperationParam ScriptServiceJobId = new("jobId");
+        public static readonly OperationParam ScriptServiceRunScriptName = new OperationParam("scriptName");
+        public static readonly OperationParam ScriptServiceRunScriptData = new OperationParam("scriptData");
+        public static readonly OperationParam ScriptServiceStartDateUTC = new OperationParam("startDateUTC");
+        public static readonly OperationParam ScriptServiceStartMinutesFromNow = new OperationParam("minutesFromNow");
+        public static readonly OperationParam ScriptServiceParentLevel = new OperationParam("parentLevel");
+        public static readonly OperationParam ScriptServiceJobId = new OperationParam("jobId");
 
-        public static readonly OperationParam MatchMakingServicePlayerRating = new("playerRating");
-        public static readonly OperationParam MatchMakingServiceMinutes = new("minutes");
-        public static readonly OperationParam MatchMakingServiceRangeDelta = new("rangeDelta");
-        public static readonly OperationParam MatchMakingServiceNumMatches = new("numMatches");
-        public static readonly OperationParam MatchMakingServiceAttributes = new("attributes");
-        public static readonly OperationParam MatchMakingServiceExtraParams = new("extraParms");
-        public static readonly OperationParam MatchMakingServicePlayerId = new("playerId");
-        public static readonly OperationParam MatchMakingServicePlaybackStreamId = new("playbackStreamId");
+        public static readonly OperationParam MatchMakingServicePlayerRating = new OperationParam("playerRating");
+        public static readonly OperationParam MatchMakingServiceMinutes = new OperationParam("minutes");
+        public static readonly OperationParam MatchMakingServiceRangeDelta = new OperationParam("rangeDelta");
+        public static readonly OperationParam MatchMakingServiceNumMatches = new OperationParam("numMatches");
+        public static readonly OperationParam MatchMakingServiceAttributes = new OperationParam("attributes");
+        public static readonly OperationParam MatchMakingServiceExtraParams = new OperationParam("extraParms");
+        public static readonly OperationParam MatchMakingServicePlayerId = new OperationParam("playerId");
+        public static readonly OperationParam MatchMakingServicePlaybackStreamId = new OperationParam("playbackStreamId");
 
-        public static readonly OperationParam OfflineMatchServicePlayerId = new("playerId");
-        public static readonly OperationParam OfflineMatchServiceRangeDelta = new("rangeDelta");
-        public static readonly OperationParam OfflineMatchServicePlaybackStreamId = new("playbackStreamId");
+        public static readonly OperationParam OfflineMatchServicePlayerId = new OperationParam("playerId");
+        public static readonly OperationParam OfflineMatchServiceRangeDelta = new OperationParam("rangeDelta");
+        public static readonly OperationParam OfflineMatchServicePlaybackStreamId = new OperationParam("playbackStreamId");
 
-        public static readonly OperationParam PlaybackStreamServiceTargetPlayerId = new("targetPlayerId");
-        public static readonly OperationParam PlaybackStreamServiceInitiatingPlayerId = new("initiatingPlayerId");
-        public static readonly OperationParam PlaybackStreamServiceMaxNumberOfStreams = new("maxNumStreams");
-        public static readonly OperationParam PlaybackStreamServiceIncludeSharedData = new("includeSharedData");
-        public static readonly OperationParam PlaybackStreamServicePlaybackStreamId = new("playbackStreamId");
-        public static readonly OperationParam PlaybackStreamServiceEventData = new("eventData");
-        public static readonly OperationParam PlaybackStreamServiceSummary = new("summary");
-        public static readonly OperationParam PlaybackStreamServiceNumDays = new("numDays");
+        public static readonly OperationParam PlaybackStreamServiceTargetPlayerId = new OperationParam("targetPlayerId");
+        public static readonly OperationParam PlaybackStreamServiceInitiatingPlayerId = new OperationParam("initiatingPlayerId");
+        public static readonly OperationParam PlaybackStreamServiceMaxNumberOfStreams = new OperationParam("maxNumStreams");
+        public static readonly OperationParam PlaybackStreamServiceIncludeSharedData = new OperationParam("includeSharedData");
+        public static readonly OperationParam PlaybackStreamServicePlaybackStreamId = new OperationParam("playbackStreamId");
+        public static readonly OperationParam PlaybackStreamServiceEventData = new OperationParam("eventData");
+        public static readonly OperationParam PlaybackStreamServiceSummary = new OperationParam("summary");
+        public static readonly OperationParam PlaybackStreamServiceNumDays = new OperationParam("numDays");
 
-        public static readonly OperationParam ProductServiceTransId = new("transId");
-        public static readonly OperationParam ProductServiceOrderId = new("orderId");
-        public static readonly OperationParam ProductServiceProductId = new("productId");
-        public static readonly OperationParam ProductServiceLanguage = new("language");
-        public static readonly OperationParam ProductServiceItemId = new("itemId");
-        public static readonly OperationParam ProductServiceReceipt = new("receipt");
-        public static readonly OperationParam ProductServiceSignedRequest = new("signed_request");
-        public static readonly OperationParam ProductServiceToken = new("token");
+        public static readonly OperationParam ProductServiceTransId = new OperationParam("transId");
+        public static readonly OperationParam ProductServiceOrderId = new OperationParam("orderId");
+        public static readonly OperationParam ProductServiceProductId = new OperationParam("productId");
+        public static readonly OperationParam ProductServiceLanguage = new OperationParam("language");
+        public static readonly OperationParam ProductServiceItemId = new OperationParam("itemId");
+        public static readonly OperationParam ProductServiceReceipt = new OperationParam("receipt");
+        public static readonly OperationParam ProductServiceSignedRequest = new OperationParam("signed_request");
+        public static readonly OperationParam ProductServiceToken = new OperationParam("token");
 
         //S3 Service
-        public static readonly OperationParam S3HandlingServiceFileCategory = new("category");
-        public static readonly OperationParam S3HandlingServiceFileDetails = new("fileDetails");
-        public static readonly OperationParam S3HandlingServiceFileId = new("fileId");
+        public static readonly OperationParam S3HandlingServiceFileCategory = new OperationParam("category");
+        public static readonly OperationParam S3HandlingServiceFileDetails = new OperationParam("fileDetails");
+        public static readonly OperationParam S3HandlingServiceFileId = new OperationParam("fileId");
 
         //Shared Identity
-        public static readonly OperationParam IdentityServiceForceSingleton = new("forceSingleton");
+        public static readonly OperationParam IdentityServiceForceSingleton = new OperationParam("forceSingleton");
 
         //RedemptionCode
-        public static readonly OperationParam RedemptionCodeServiceScanCode = new("scanCode");
-        public static readonly OperationParam RedemptionCodeServiceCodeType = new("codeType");
-        public static readonly OperationParam RedemptionCodeServiceCustomRedemptionInfo = new("customRedemptionInfo");
+        public static readonly OperationParam RedemptionCodeServiceScanCode = new OperationParam("scanCode");
+        public static readonly OperationParam RedemptionCodeServiceCodeType = new OperationParam("codeType");
+        public static readonly OperationParam RedemptionCodeServiceCustomRedemptionInfo = new OperationParam("customRedemptionInfo");
 
         //DataStream
-        public static readonly OperationParam DataStreamEventName = new("eventName");
-        public static readonly OperationParam DataStreamEventProperties = new("eventProperties");
-        public static readonly OperationParam DataStreamCrashType = new("crashType");
-        public static readonly OperationParam DataStreamErrorMsg = new("errorMsg");
-        public static readonly OperationParam DataStreamCrashInfo = new("crashJson");
-        public static readonly OperationParam DataStreamCrashLog = new("crashLog");
-        public static readonly OperationParam DataStreamUserName = new("userName");
-        public static readonly OperationParam DataStreamUserEmail = new("userEmail");
-        public static readonly OperationParam DataStreamUserNotes = new("userNotes");
-        public static readonly OperationParam DataStreamUserSubmitted = new("userSubmitted");
+        public static readonly OperationParam DataStreamEventName = new OperationParam("eventName");
+        public static readonly OperationParam DataStreamEventProperties = new OperationParam("eventProperties");
+        public static readonly OperationParam DataStreamCrashType = new OperationParam("crashType");
+        public static readonly OperationParam DataStreamErrorMsg = new OperationParam("errorMsg");
+        public static readonly OperationParam DataStreamCrashInfo = new OperationParam("crashJson");
+        public static readonly OperationParam DataStreamCrashLog = new OperationParam("crashLog");
+        public static readonly OperationParam DataStreamUserName = new OperationParam("userName");
+        public static readonly OperationParam DataStreamUserEmail = new OperationParam("userEmail");
+        public static readonly OperationParam DataStreamUserNotes = new OperationParam("userNotes");
+        public static readonly OperationParam DataStreamUserSubmitted = new OperationParam("userSubmitted");
 
         // Profanity
-        public static readonly OperationParam ProfanityText = new("text");
-        public static readonly OperationParam ProfanityReplaceSymbol = new("replaceSymbol");
-        public static readonly OperationParam ProfanityFlagEmail = new("flagEmail");
-        public static readonly OperationParam ProfanityFlagPhone = new("flagPhone");
-        public static readonly OperationParam ProfanityFlagUrls = new("flagUrls");
-        public static readonly OperationParam ProfanityLanguages = new("languages");
+        public static readonly OperationParam ProfanityText = new OperationParam("text");
+        public static readonly OperationParam ProfanityReplaceSymbol = new OperationParam("replaceSymbol");
+        public static readonly OperationParam ProfanityFlagEmail = new OperationParam("flagEmail");
+        public static readonly OperationParam ProfanityFlagPhone = new OperationParam("flagPhone");
+        public static readonly OperationParam ProfanityFlagUrls = new OperationParam("flagUrls");
+        public static readonly OperationParam ProfanityLanguages = new OperationParam("languages");
 
         //File upload
-        public static readonly OperationParam UploadLocalPath = new("localPath");
-        public static readonly OperationParam UploadCloudPath = new("cloudPath");
-        public static readonly OperationParam UploadCloudFilename = new("cloudFilename");
-        public static readonly OperationParam UploadShareable = new("shareable");
-        public static readonly OperationParam UploadReplaceIfExists = new("replaceIfExists");
-        public static readonly OperationParam UploadFileSize = new("fileSize");
-        public static readonly OperationParam UploadRecurse = new("recurse");
-        public static readonly OperationParam UploadPath = new("path");
+        public static readonly OperationParam UploadLocalPath = new OperationParam("localPath");
+        public static readonly OperationParam UploadCloudPath = new OperationParam("cloudPath");
+        public static readonly OperationParam UploadCloudFilename = new OperationParam("cloudFilename");
+        public static readonly OperationParam UploadShareable = new OperationParam("shareable");
+        public static readonly OperationParam UploadReplaceIfExists = new OperationParam("replaceIfExists");
+        public static readonly OperationParam UploadFileSize = new OperationParam("fileSize");
+        public static readonly OperationParam UploadRecurse = new OperationParam("recurse");
+        public static readonly OperationParam UploadPath = new OperationParam("path");
 
         //group
-        public static readonly OperationParam GroupId = new("groupId");
-        public static readonly OperationParam GroupProfileId = new("profileId");
-        public static readonly OperationParam GroupRole = new("role");
-        public static readonly OperationParam GroupAttributes = new("attributes");
-        public static readonly OperationParam GroupName = new("name");
-        public static readonly OperationParam GroupType = new("groupType");
-        public static readonly OperationParam GroupTypes = new("groupTypes");
-        public static readonly OperationParam GroupEntityType = new("entityType");
-        public static readonly OperationParam GroupIsOpenGroup = new("isOpenGroup");
-        public static readonly OperationParam GroupAcl = new("acl");
-        public static readonly OperationParam GroupData = new("data");
-        public static readonly OperationParam GroupOwnerAttributes = new("ownerAttributes");
-        public static readonly OperationParam GroupDefaultMemberAttributes = new("defaultMemberAttributes");
-        public static readonly OperationParam GroupIsOwnedByGroupMember = new("isOwnedByGroupMember");
-        public static readonly OperationParam GroupSummaryData = new("summaryData");
-        public static readonly OperationParam GroupEntityId = new("entityId");
-        public static readonly OperationParam GroupVersion = new("version");
-        public static readonly OperationParam GroupContext = new("context");
-        public static readonly OperationParam GroupPageOffset = new("pageOffset");
-        public static readonly OperationParam GroupAutoJoinStrategy = new("autoJoinStrategy");
-        public static readonly OperationParam GroupWhere = new("where");
-        public static readonly OperationParam GroupMaxReturn = new("maxReturn");
+        public static readonly OperationParam GroupId = new OperationParam("groupId");
+        public static readonly OperationParam GroupProfileId = new OperationParam("profileId");
+        public static readonly OperationParam GroupRole = new OperationParam("role");
+        public static readonly OperationParam GroupAttributes = new OperationParam("attributes");
+        public static readonly OperationParam GroupName = new OperationParam("name");
+        public static readonly OperationParam GroupType = new OperationParam("groupType");
+        public static readonly OperationParam GroupTypes = new OperationParam("groupTypes");
+        public static readonly OperationParam GroupEntityType = new OperationParam("entityType");
+        public static readonly OperationParam GroupIsOpenGroup = new OperationParam("isOpenGroup");
+        public static readonly OperationParam GroupAcl = new OperationParam("acl");
+        public static readonly OperationParam GroupData = new OperationParam("data");
+        public static readonly OperationParam GroupOwnerAttributes = new OperationParam("ownerAttributes");
+        public static readonly OperationParam GroupDefaultMemberAttributes = new OperationParam("defaultMemberAttributes");
+        public static readonly OperationParam GroupIsOwnedByGroupMember = new OperationParam("isOwnedByGroupMember");
+        public static readonly OperationParam GroupSummaryData = new OperationParam("summaryData");
+        public static readonly OperationParam GroupEntityId = new OperationParam("entityId");
+        public static readonly OperationParam GroupVersion = new OperationParam("version");
+        public static readonly OperationParam GroupContext = new OperationParam("context");
+        public static readonly OperationParam GroupPageOffset = new OperationParam("pageOffset");
+        public static readonly OperationParam GroupAutoJoinStrategy = new OperationParam("autoJoinStrategy");
+        public static readonly OperationParam GroupWhere = new OperationParam("where");
+        public static readonly OperationParam GroupMaxReturn = new OperationParam("maxReturn");
         
         //group file
-        public static readonly OperationParam FolderPath = new("folderPath");
-        public static readonly OperationParam FileName = new("filename");
-        public static readonly OperationParam FullPathFilename = new("fullPathFilename");
-        public static readonly OperationParam FileId = new("fileId");
-        public static readonly OperationParam Version = new("version");
-        public static readonly OperationParam NewTreeId = new("newTreeId");
-        public static readonly OperationParam TreeVersion = new("treeVersion");
-        public static readonly OperationParam NewFilename = new("newFilename");
-        public static readonly OperationParam OverwriteIfPresent = new("overwriteIfPresent");
-        public static readonly OperationParam Recurse = new("recurse");
-        public static readonly OperationParam UserCloudPath = new("userCloudPath");
-        public static readonly OperationParam UserCloudFilename = new("userCloudFilename");
-        public static readonly OperationParam GroupTreeId = new("groupTreeId");
-        public static readonly OperationParam GroupFilename = new("groupFilename");
-        public static readonly OperationParam GroupFileACL = new("groupFileAcl");
-        public static readonly OperationParam NewACL = new("newAcl");
+        public static readonly OperationParam FolderPath = new OperationParam("folderPath");
+        public static readonly OperationParam FileName = new OperationParam("filename");
+        public static readonly OperationParam FullPathFilename = new OperationParam("fullPathFilename");
+        public static readonly OperationParam FileId = new OperationParam("fileId");
+        public static readonly OperationParam Version = new OperationParam("version");
+        public static readonly OperationParam NewTreeId = new OperationParam("newTreeId");
+        public static readonly OperationParam TreeVersion = new OperationParam("treeVersion");
+        public static readonly OperationParam NewFilename = new OperationParam("newFilename");
+        public static readonly OperationParam OverwriteIfPresent = new OperationParam("overwriteIfPresent");
+        public static readonly OperationParam Recurse = new OperationParam("recurse");
+        public static readonly OperationParam UserCloudPath = new OperationParam("userCloudPath");
+        public static readonly OperationParam UserCloudFilename = new OperationParam("userCloudFilename");
+        public static readonly OperationParam GroupTreeId = new OperationParam("groupTreeId");
+        public static readonly OperationParam GroupFilename = new OperationParam("groupFilename");
+        public static readonly OperationParam GroupFileACL = new OperationParam("groupFileAcl");
+        public static readonly OperationParam NewACL = new OperationParam("newAcl");
 
 
         //GlobalFile
-        public static readonly OperationParam GlobalFileServiceFileId = new("fileId");
-        public static readonly OperationParam GlobalFileServiceFolderPath = new("folderPath");
-        public static readonly OperationParam GlobalFileServiceFileName = new("filename");
-        public static readonly OperationParam GlobalFileServiceRecurse = new("recurse");
+        public static readonly OperationParam GlobalFileServiceFileId = new OperationParam("fileId");
+        public static readonly OperationParam GlobalFileServiceFolderPath = new OperationParam("folderPath");
+        public static readonly OperationParam GlobalFileServiceFileName = new OperationParam("filename");
+        public static readonly OperationParam GlobalFileServiceRecurse = new OperationParam("recurse");
 
         //mail
-        public static readonly OperationParam Subject = new("subject");
-        public static readonly OperationParam Body = new("body");
-        public static readonly OperationParam ServiceParams = new("serviceParams");
-        public static readonly OperationParam EmailAddress = new("emailAddress");
-        public static readonly OperationParam EmailAddresses = new("emailAddresses");
+        public static readonly OperationParam Subject = new OperationParam("subject");
+        public static readonly OperationParam Body = new OperationParam("body");
+        public static readonly OperationParam ServiceParams = new OperationParam("serviceParams");
+        public static readonly OperationParam EmailAddress = new OperationParam("emailAddress");
+        public static readonly OperationParam EmailAddresses = new OperationParam("emailAddresses");
 
-        public static readonly OperationParam LeaderboardId = new("leaderboardId");
-        public static readonly OperationParam DivSetId = new("divSetId");
-        public static readonly OperationParam VersionId = new("versionId");
-        public static readonly OperationParam TournamentCode = new("tournamentCode");
-        public static readonly OperationParam InitialScore = new("initialScore");
-        public static readonly OperationParam Score = new("score");
-        public static readonly OperationParam RoundStartedEpoch = new("roundStartedEpoch");
-        public static readonly OperationParam Data = new("data");
+        public static readonly OperationParam LeaderboardId = new OperationParam("leaderboardId");
+        public static readonly OperationParam DivSetId = new OperationParam("divSetId");
+        public static readonly OperationParam VersionId = new OperationParam("versionId");
+        public static readonly OperationParam TournamentCode = new OperationParam("tournamentCode");
+        public static readonly OperationParam InitialScore = new OperationParam("initialScore");
+        public static readonly OperationParam Score = new OperationParam("score");
+        public static readonly OperationParam RoundStartedEpoch = new OperationParam("roundStartedEpoch");
+        public static readonly OperationParam Data = new OperationParam("data");
 
         // chat
-        public static readonly OperationParam ChatChannelId = new("channelId");
-        public static readonly OperationParam ChatMaxReturn = new("maxReturn");
-        public static readonly OperationParam ChatMessageId = new("msgId");
-        public static readonly OperationParam ChatVersion = new("version");
+        public static readonly OperationParam ChatChannelId = new OperationParam("channelId");
+        public static readonly OperationParam ChatMaxReturn = new OperationParam("maxReturn");
+        public static readonly OperationParam ChatMessageId = new OperationParam("msgId");
+        public static readonly OperationParam ChatVersion = new OperationParam("version");
         
-        public static readonly OperationParam ChatChannelType = new("channelType");
-        public static readonly OperationParam ChatChannelSubId = new("channelSubId");
-        public static readonly OperationParam ChatContent = new("content");
-        public static readonly OperationParam ChatText = new("text");
+        public static readonly OperationParam ChatChannelType = new OperationParam("channelType");
+        public static readonly OperationParam ChatChannelSubId = new OperationParam("channelSubId");
+        public static readonly OperationParam ChatContent = new OperationParam("content");
+        public static readonly OperationParam ChatText = new OperationParam("text");
 
-        public static readonly OperationParam ChatRich = new("rich");
-        public static readonly OperationParam ChatRecordInHistory = new("recordInHistory");
+        public static readonly OperationParam ChatRich = new OperationParam("rich");
+        public static readonly OperationParam ChatRecordInHistory = new OperationParam("recordInHistory");
 
         // TODO:: do we enumerate these ? [smrj]
         // chat channel types 
-        public static readonly OperationParam AllChannelType = new("all");
-        public static readonly OperationParam GlobalChannelType = new("gl");
-        public static readonly OperationParam GroupChannelType = new("gr");
+        public static readonly OperationParam AllChannelType = new OperationParam("all");
+        public static readonly OperationParam GlobalChannelType = new OperationParam("gl");
+        public static readonly OperationParam GroupChannelType = new OperationParam("gr");
 
         // messaging
-        public static readonly OperationParam MessagingMessageBox = new("msgbox");
-        public static readonly OperationParam MessagingMessageIds = new("msgIds");
-        public static readonly OperationParam MessagingMarkAsRead = new("markAsRead");
-        public static readonly OperationParam MessagingContext = new("context");
-        public static readonly OperationParam MessagingPageOffset = new("pageOffset");
-        public static readonly OperationParam MessagingFromName = new("fromName");
-        public static readonly OperationParam MessagingToProfileIds = new("toProfileIds");
-        public static readonly OperationParam MessagingContent = new("contentJson");
-        public static readonly OperationParam MessagingSubject = new("subject");
-        public static readonly OperationParam MessagingText = new("text");
+        public static readonly OperationParam MessagingMessageBox = new OperationParam("msgbox");
+        public static readonly OperationParam MessagingMessageIds = new OperationParam("msgIds");
+        public static readonly OperationParam MessagingMarkAsRead = new OperationParam("markAsRead");
+        public static readonly OperationParam MessagingContext = new OperationParam("context");
+        public static readonly OperationParam MessagingPageOffset = new OperationParam("pageOffset");
+        public static readonly OperationParam MessagingFromName = new OperationParam("fromName");
+        public static readonly OperationParam MessagingToProfileIds = new OperationParam("toProfileIds");
+        public static readonly OperationParam MessagingContent = new OperationParam("contentJson");
+        public static readonly OperationParam MessagingSubject = new OperationParam("subject");
+        public static readonly OperationParam MessagingText = new OperationParam("text");
 
-        public static readonly OperationParam InboxMessageType = new("inbox");
-        public static readonly OperationParam SentMessageType = new("sent");
+        public static readonly OperationParam InboxMessageType = new OperationParam("inbox");
+        public static readonly OperationParam SentMessageType = new OperationParam("sent");
 
         // lobby
-        public static readonly OperationParam EntryId = new("entryId");
-        public static readonly OperationParam LobbyRoomType = new("lobbyType");
-        public static readonly OperationParam LobbyTypes = new("lobbyTypes");
-        public static readonly OperationParam LobbyRating = new("rating");
-        public static readonly OperationParam LobbyAlgorithm = new("algo");
-        public static readonly OperationParam LobbyMaxSteps = new("maxSteps");
-        public static readonly OperationParam LobbyStrategy = new("strategy");
-        public static readonly OperationParam LobbyAlignment = new("alignment");
-        public static readonly OperationParam LobbyRanges = new("ranges");
-        public static readonly OperationParam LobbyFilterJson = new("filterJson");
-        public static readonly OperationParam LobbySettings = new("settings");
-        public static readonly OperationParam LobbyTimeoutSeconds = new("timeoutSecs");
-        public static readonly OperationParam LobbyIsReady = new("isReady");
-        public static readonly OperationParam LobbyOtherUserCxIds = new("otherUserCxIds");
-        public static readonly OperationParam LobbyExtraJson = new("extraJson");
-        public static readonly OperationParam LobbyTeamCode = new("teamCode");
-        public static readonly OperationParam LobbyIdentifier = new("lobbyId");
-        public static readonly OperationParam LobbyToTeamName = new("toTeamCode");
-        public static readonly OperationParam LobbySignalData = new("signalData");
-        public static readonly OperationParam LobbyConnectionId = new("cxId");
-        public static readonly OperationParam PingData = new("pingData");
-        public static readonly OperationParam LobbyMinRating = new("minRating");
-        public static readonly OperationParam LobbyMaxRating = new("maxRating");
+        public static readonly OperationParam EntryId = new OperationParam("entryId");
+        public static readonly OperationParam LobbyRoomType = new OperationParam("lobbyType");
+        public static readonly OperationParam LobbyTypes = new OperationParam("lobbyTypes");
+        public static readonly OperationParam LobbyRating = new OperationParam("rating");
+        public static readonly OperationParam LobbyAlgorithm = new OperationParam("algo");
+        public static readonly OperationParam LobbyMaxSteps = new OperationParam("maxSteps");
+        public static readonly OperationParam LobbyStrategy = new OperationParam("strategy");
+        public static readonly OperationParam LobbyAlignment = new OperationParam("alignment");
+        public static readonly OperationParam LobbyRanges = new OperationParam("ranges");
+        public static readonly OperationParam LobbyFilterJson = new OperationParam("filterJson");
+        public static readonly OperationParam LobbySettings = new OperationParam("settings");
+        public static readonly OperationParam LobbyTimeoutSeconds = new OperationParam("timeoutSecs");
+        public static readonly OperationParam LobbyIsReady = new OperationParam("isReady");
+        public static readonly OperationParam LobbyOtherUserCxIds = new OperationParam("otherUserCxIds");
+        public static readonly OperationParam LobbyExtraJson = new OperationParam("extraJson");
+        public static readonly OperationParam LobbyTeamCode = new OperationParam("teamCode");
+        public static readonly OperationParam LobbyIdentifier = new OperationParam("lobbyId");
+        public static readonly OperationParam LobbyToTeamName = new OperationParam("toTeamCode");
+        public static readonly OperationParam LobbySignalData = new OperationParam("signalData");
+        public static readonly OperationParam LobbyConnectionId = new OperationParam("cxId");
+        public static readonly OperationParam PingData = new OperationParam("pingData");
+        public static readonly OperationParam LobbyMinRating = new OperationParam("minRating");
+        public static readonly OperationParam LobbyMaxRating = new OperationParam("maxRating");
 
-        public static readonly OperationParam CompoundAlgos = new("algos");
-        public static readonly OperationParam CompoundRanges = new("compound-ranges");
-        public static readonly OperationParam LobbyCritera = new("criteriaJson");
-        public static readonly OperationParam Critera = new("criteria");
-        public static readonly OperationParam CriteraPing = new("ping");
-        public static readonly OperationParam CriteraRating = new("rating");
-        public static readonly OperationParam StrategyRangedPercent = new("ranged-percent");
-        public static readonly OperationParam StrategyRangedAbsolute = new("ranged-absolute");
-        public static readonly OperationParam StrategyAbsolute = new("absolute");
-        public static readonly OperationParam StrategyCompound = new("compound");
-        public static readonly OperationParam AlignmentCenter = new("center");
+        public static readonly OperationParam CompoundAlgos = new OperationParam("algos");
+        public static readonly OperationParam CompoundRanges = new OperationParam("compound-ranges");
+        public static readonly OperationParam LobbyCritera = new OperationParam("criteriaJson");
+        public static readonly OperationParam Critera = new OperationParam("criteria");
+        public static readonly OperationParam CriteraPing = new OperationParam("ping");
+        public static readonly OperationParam CriteraRating = new OperationParam("rating");
+        public static readonly OperationParam StrategyRangedPercent = new OperationParam("ranged-percent");
+        public static readonly OperationParam StrategyRangedAbsolute = new OperationParam("ranged-absolute");
+        public static readonly OperationParam StrategyAbsolute = new OperationParam("absolute");
+        public static readonly OperationParam StrategyCompound = new OperationParam("compound");
+        public static readonly OperationParam AlignmentCenter = new OperationParam("center");
         //custom entity
-        public static readonly OperationParam CustomEntityServiceEntityType = new("entityType");
-        public static readonly OperationParam CustomEntityServiceDeleteCriteria = new("deleteCriteria");
-        public static readonly OperationParam CustomEntityServiceEntityId = new("entityId");
-        public static readonly OperationParam CustomEntityServiceVersion = new("version");
-        public static readonly OperationParam CustomEntityServiceFieldsJson = new("fieldsJson");
-        public static readonly OperationParam CustomEntityServiceWhereJson = new("whereJson");
-        public static readonly OperationParam CustomEntityServiceRowsPerPage = new("rowsPerPage");
-        public static readonly OperationParam CustomEntityServiceSearchJson = new("searchJson");
-        public static readonly OperationParam CustomEntityServiceSortJson = new("sortJson");
-        public static readonly OperationParam CustomEntityServiceDoCount = new("doCount");
-        public static readonly OperationParam CustomEntityServiceContext = new("context");
-        public static readonly OperationParam CustomEntityServicePageOffset= new("pageOffset");
-        public static readonly OperationParam CustomEntityServiceTimeToLive = new("timeToLive");
-        public static readonly OperationParam CustomEntityServiceAcl = new("acl");
-        public static readonly OperationParam CustomEntityServiceDataJson = new("dataJson");
-        public static readonly OperationParam CustomEntityServiceIsOwned = new("isOwned");
-        public static readonly OperationParam CustomEntityServiceMaxReturn = new("maxReturn");
-        public static readonly OperationParam CustomEntityServiceShardKeyJson = new("shardKeyJson");
+        public static readonly OperationParam CustomEntityServiceEntityType = new OperationParam("entityType");
+        public static readonly OperationParam CustomEntityServiceDeleteCriteria = new OperationParam("deleteCriteria");
+        public static readonly OperationParam CustomEntityServiceEntityId = new OperationParam("entityId");
+        public static readonly OperationParam CustomEntityServiceVersion = new OperationParam("version");
+        public static readonly OperationParam CustomEntityServiceFieldsJson = new OperationParam("fieldsJson");
+        public static readonly OperationParam CustomEntityServiceWhereJson = new OperationParam("whereJson");
+        public static readonly OperationParam CustomEntityServiceRowsPerPage = new OperationParam("rowsPerPage");
+        public static readonly OperationParam CustomEntityServiceSearchJson = new OperationParam("searchJson");
+        public static readonly OperationParam CustomEntityServiceSortJson = new OperationParam("sortJson");
+        public static readonly OperationParam CustomEntityServiceDoCount = new OperationParam("doCount");
+        public static readonly OperationParam CustomEntityServiceContext = new OperationParam("context");
+        public static readonly OperationParam CustomEntityServicePageOffset= new OperationParam("pageOffset");
+        public static readonly OperationParam CustomEntityServiceTimeToLive = new OperationParam("timeToLive");
+        public static readonly OperationParam CustomEntityServiceAcl = new OperationParam("acl");
+        public static readonly OperationParam CustomEntityServiceDataJson = new OperationParam("dataJson");
+        public static readonly OperationParam CustomEntityServiceIsOwned = new OperationParam("isOwned");
+        public static readonly OperationParam CustomEntityServiceMaxReturn = new OperationParam("maxReturn");
+        public static readonly OperationParam CustomEntityServiceShardKeyJson = new OperationParam("shardKeyJson");
 
         //item catalog
-        public static readonly OperationParam ItemCatalogServiceDefId = new("defId");
-        public static readonly OperationParam ItemCatalogServiceContext = new("context");
-        public static readonly OperationParam ItemCatalogServicePageOffset = new("pageOffset");
+        public static readonly OperationParam ItemCatalogServiceDefId = new OperationParam("defId");
+        public static readonly OperationParam ItemCatalogServiceContext = new OperationParam("context");
+        public static readonly OperationParam ItemCatalogServicePageOffset = new OperationParam("pageOffset");
 
         //userInventory
-        public static readonly OperationParam UserItemsServiceDefId = new("defId");
-        public static readonly OperationParam UserItemsServiceQuantity = new("quantity");
-        public static readonly OperationParam UserItemsServiceIncludeDef = new("includeDef");
-        public static readonly OperationParam UserItemsServiceItemId = new("itemId");
-        public static readonly OperationParam UserItemsServiceCriteria = new("criteria");
-        public static readonly OperationParam UserItemsServiceContext = new("context");
-        public static readonly OperationParam UserItemsServicePageOffset = new("pageOffset");
-        public static readonly OperationParam UserItemsServiceVersion = new("version");
-        public static readonly OperationParam UserItemsServiceImmediate = new("immediate");
-        public static readonly OperationParam UserItemsServiceProfileId = new("profileId");
-        public static readonly OperationParam UserItemsServiceShopId = new("shopId");
-        public static readonly OperationParam UserItemsServiceNewItemData = new("newItemData");
-        public static readonly OperationParam UserItemsServiceOptionsJson = new("optionsJson");
-        public static readonly OperationParam UserItemsServiceIncludePromotionDetails = new("includePromotionDetails");
+        public static readonly OperationParam UserItemsServiceDefId = new OperationParam("defId");
+        public static readonly OperationParam UserItemsServiceQuantity = new OperationParam("quantity");
+        public static readonly OperationParam UserItemsServiceIncludeDef = new OperationParam("includeDef");
+        public static readonly OperationParam UserItemsServiceItemId = new OperationParam("itemId");
+        public static readonly OperationParam UserItemsServiceCriteria = new OperationParam("criteria");
+        public static readonly OperationParam UserItemsServiceContext = new OperationParam("context");
+        public static readonly OperationParam UserItemsServicePageOffset = new OperationParam("pageOffset");
+        public static readonly OperationParam UserItemsServiceVersion = new OperationParam("version");
+        public static readonly OperationParam UserItemsServiceImmediate = new OperationParam("immediate");
+        public static readonly OperationParam UserItemsServiceProfileId = new OperationParam("profileId");
+        public static readonly OperationParam UserItemsServiceShopId = new OperationParam("shopId");
+        public static readonly OperationParam UserItemsServiceNewItemData = new OperationParam("newItemData");
+        public static readonly OperationParam UserItemsServiceOptionsJson = new OperationParam("optionsJson");
+        public static readonly OperationParam UserItemsServiceIncludePromotionDetails = new OperationParam("includePromotionDetails");
 
         //global app
-        public static readonly OperationParam GlobalAppPropertyNames = new("propertyNames");
-        public static readonly OperationParam GlobalAppCategories = new("categories");
+        public static readonly OperationParam GlobalAppPropertyNames = new OperationParam("propertyNames");
+        public static readonly OperationParam GlobalAppCategories = new OperationParam("categories");
 
         #endregion
 
@@ -607,33 +606,34 @@ namespace BrainCloud
 
         #region Overrides and Operators
 
-        public readonly override bool Equals(object obj)
+        public override bool Equals(object obj)
         {
-            if (obj is not OperationParam s)
-                return false;
-
-            return Equals(s);
+            return obj is OperationParam other && Equals(other);
         }
 
-        public readonly bool Equals(OperationParam other)
+        public bool Equals(OperationParam other)
         {
-            if (GetType() != other.GetType())
-                return false;
-
             return Value == other.Value;
         }
 
-        public readonly int CompareTo(OperationParam other)
+        public int CompareTo(object obj)
         {
-            if (GetType() != other.GetType())
-                return 1;
+            if (obj is OperationParam other)
+            {
+                return CompareTo(other);
+            }
 
+            return 1;
+        }
+
+        public int CompareTo(OperationParam other)
+        {
             return Value.CompareTo(other.Value);
         }
 
-        public readonly override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Value.GetHashCode();
 
-        public readonly override string ToString() => Value;
+        public override string ToString() => Value;
 
         public static implicit operator string(OperationParam v) => v.Value;
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceName.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceName.cs
@@ -5,57 +5,57 @@
 
 namespace BrainCloud
 {
-    public readonly struct ServiceName : System.IEquatable<ServiceName>, System.IComparable<ServiceName>
+    public readonly struct ServiceName : System.IEquatable<ServiceName>, System.IComparable, System.IComparable<ServiceName>
     {
         #region brainCloud Service Names
 
         // Services
-        public static readonly ServiceName AsyncMatch            = new("asyncMatch");
-        public static readonly ServiceName Authenticate          = new("authenticationV2");
-        public static readonly ServiceName DataStream            = new("dataStream");
-        public static readonly ServiceName Entity                = new("entity");
-        public static readonly ServiceName Event                 = new("event");
-        public static readonly ServiceName File                  = new("file");
-        public static readonly ServiceName Friend                = new("friend");
-        public static readonly ServiceName Gamification          = new("gamification");
-        public static readonly ServiceName GlobalApp             = new("globalApp");
-        public static readonly ServiceName GlobalEntity          = new("globalEntity");
-        public static readonly ServiceName GlobalStatistics      = new("globalGameStatistics");
-        public static readonly ServiceName Group                 = new("group");
-        public static readonly ServiceName HeartBeat             = new("heartbeat");
-        public static readonly ServiceName Identity              = new("identity");
-        public static readonly ServiceName ItemCatalog           = new("itemCatalog");
-        public static readonly ServiceName UserItems             = new("userItems");
-        public static readonly ServiceName Mail                  = new("mail");
-        public static readonly ServiceName MatchMaking           = new("matchMaking");
-        public static readonly ServiceName OneWayMatch           = new("onewayMatch");
-        public static readonly ServiceName PlaybackStream        = new("playbackStream");
-        public static readonly ServiceName PlayerState           = new("playerState");
-        public static readonly ServiceName PlayerStatistics      = new("playerStatistics");
-        public static readonly ServiceName PlayerStatisticsEvent = new("playerStatisticsEvent");
-        public static readonly ServiceName Presence              = new("presence");
-        public static readonly ServiceName Profanity             = new("profanity");
-        public static readonly ServiceName PushNotification      = new("pushNotification");
-        public static readonly ServiceName RedemptionCode        = new("redemptionCode");
-        public static readonly ServiceName S3Handling            = new("s3Handling");
-        public static readonly ServiceName Script                = new("script");
-        public static readonly ServiceName ServerTime            = new("time");
-        public static readonly ServiceName Leaderboard           = new("leaderboard");
-        public static readonly ServiceName Twitter               = new("twitter");
-        public static readonly ServiceName Time                  = new("time");
-        public static readonly ServiceName Tournament            = new("tournament");
-        public static readonly ServiceName GlobalFile            = new("globalFileV3");
-        public static readonly ServiceName CustomEntity          = new("customEntity");
-        public static readonly ServiceName RTTRegistration       = new("rttRegistration");
-        public static readonly ServiceName RTT                   = new("rtt");
-        public static readonly ServiceName Relay                 = new("relay");
-        public static readonly ServiceName Chat                  = new("chat");
-        public static readonly ServiceName Messaging             = new("messaging");
-        public static readonly ServiceName Lobby                 = new("lobby");
-        public static readonly ServiceName VirtualCurrency       = new("virtualCurrency");
-        public static readonly ServiceName AppStore              = new("appStore");
-        public static readonly ServiceName BlockChain            = new("blockchain");
-        public static readonly ServiceName GroupFile             = new("groupFile");
+        public static readonly ServiceName AsyncMatch            = new ServiceName("asyncMatch");
+        public static readonly ServiceName Authenticate          = new ServiceName("authenticationV2");
+        public static readonly ServiceName DataStream            = new ServiceName("dataStream");
+        public static readonly ServiceName Entity                = new ServiceName("entity");
+        public static readonly ServiceName Event                 = new ServiceName("event");
+        public static readonly ServiceName File                  = new ServiceName("file");
+        public static readonly ServiceName Friend                = new ServiceName("friend");
+        public static readonly ServiceName Gamification          = new ServiceName("gamification");
+        public static readonly ServiceName GlobalApp             = new ServiceName("globalApp");
+        public static readonly ServiceName GlobalEntity          = new ServiceName("globalEntity");
+        public static readonly ServiceName GlobalStatistics      = new ServiceName("globalGameStatistics");
+        public static readonly ServiceName Group                 = new ServiceName("group");
+        public static readonly ServiceName HeartBeat             = new ServiceName("heartbeat");
+        public static readonly ServiceName Identity              = new ServiceName("identity");
+        public static readonly ServiceName ItemCatalog           = new ServiceName("itemCatalog");
+        public static readonly ServiceName UserItems             = new ServiceName("userItems");
+        public static readonly ServiceName Mail                  = new ServiceName("mail");
+        public static readonly ServiceName MatchMaking           = new ServiceName("matchMaking");
+        public static readonly ServiceName OneWayMatch           = new ServiceName("onewayMatch");
+        public static readonly ServiceName PlaybackStream        = new ServiceName("playbackStream");
+        public static readonly ServiceName PlayerState           = new ServiceName("playerState");
+        public static readonly ServiceName PlayerStatistics      = new ServiceName("playerStatistics");
+        public static readonly ServiceName PlayerStatisticsEvent = new ServiceName("playerStatisticsEvent");
+        public static readonly ServiceName Presence              = new ServiceName("presence");
+        public static readonly ServiceName Profanity             = new ServiceName("profanity");
+        public static readonly ServiceName PushNotification      = new ServiceName("pushNotification");
+        public static readonly ServiceName RedemptionCode        = new ServiceName("redemptionCode");
+        public static readonly ServiceName S3Handling            = new ServiceName("s3Handling");
+        public static readonly ServiceName Script                = new ServiceName("script");
+        public static readonly ServiceName ServerTime            = new ServiceName("time");
+        public static readonly ServiceName Leaderboard           = new ServiceName("leaderboard");
+        public static readonly ServiceName Twitter               = new ServiceName("twitter");
+        public static readonly ServiceName Time                  = new ServiceName("time");
+        public static readonly ServiceName Tournament            = new ServiceName("tournament");
+        public static readonly ServiceName GlobalFile            = new ServiceName("globalFileV3");
+        public static readonly ServiceName CustomEntity          = new ServiceName("customEntity");
+        public static readonly ServiceName RTTRegistration       = new ServiceName("rttRegistration");
+        public static readonly ServiceName RTT                   = new ServiceName("rtt");
+        public static readonly ServiceName Relay                 = new ServiceName("relay");
+        public static readonly ServiceName Chat                  = new ServiceName("chat");
+        public static readonly ServiceName Messaging             = new ServiceName("messaging");
+        public static readonly ServiceName Lobby                 = new ServiceName("lobby");
+        public static readonly ServiceName VirtualCurrency       = new ServiceName("virtualCurrency");
+        public static readonly ServiceName AppStore              = new ServiceName("appStore");
+        public static readonly ServiceName BlockChain            = new ServiceName("blockchain");
+        public static readonly ServiceName GroupFile             = new ServiceName("groupFile");
 
         #endregion
 
@@ -68,33 +68,34 @@ namespace BrainCloud
 
         #region Overrides and Operators
 
-        public readonly override bool Equals(object obj)
+        public override bool Equals(object obj)
         {
-            if (obj is not ServiceName s)
-                return false;
-
-            return Equals(s);
+            return obj is ServiceName other && Equals(other);
         }
 
-        public readonly bool Equals(ServiceName other)
+        public bool Equals(ServiceName other)
         {
-            if (GetType() != other.GetType())
-                return false;
-
             return Value == other.Value;
         }
 
-        public readonly int CompareTo(ServiceName other)
+        public int CompareTo(object obj)
         {
-            if (GetType() != other.GetType())
-                return 1;
+            if (obj is ServiceName other)
+            {
+                return CompareTo(other);
+            }
 
+            return 1;
+        }
+
+        public int CompareTo(ServiceName other)
+        {
             return Value.CompareTo(other.Value);
         }
 
-        public readonly override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Value.GetHashCode();
 
-        public readonly override string ToString() => Value;
+        public override string ToString() => Value;
 
         public static implicit operator string(ServiceName v) => v.Value;
 

--- a/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
+++ b/BrainCloudClient/Assets/BrainCloud/Client/BrainCloud/ServiceOperation.cs
@@ -8,533 +8,533 @@ namespace BrainCloud
     /**
      * List of all available service operations. The values are mapped to server keys which represent that operation.
      */
-    public readonly struct ServiceOperation : System.IEquatable<ServiceOperation>, System.IComparable<ServiceOperation>
+    public readonly struct ServiceOperation : System.IEquatable<ServiceOperation>, System.IComparable, System.IComparable<ServiceOperation>
     {
         #region brainCloud Service Operations
 
-        public static readonly ServiceOperation Authenticate = new("AUTHENTICATE");
-        public static readonly ServiceOperation Attach = new("ATTACH");
-        public static readonly ServiceOperation Merge = new("MERGE");
-        public static readonly ServiceOperation Detach = new("DETACH");
-        public static readonly ServiceOperation GetServerVersion = new("GET_SERVER_VERSION");
-        public static readonly ServiceOperation ResetEmailPassword = new("RESET_EMAIL_PASSWORD");
-        public static readonly ServiceOperation ResetEmailPasswordWithExpiry = new("RESET_EMAIL_PASSWORD_WITH_EXPIRY");
-        public static readonly ServiceOperation ResetEmailPasswordAdvanced = new("RESET_EMAIL_PASSWORD_ADVANCED");
-        public static readonly ServiceOperation ResetEmailPasswordAdvancedWithExpiry = new("RESET_EMAIL_PASSWORD_ADVANCED_WITH_EXPIRY");
-        public static readonly ServiceOperation ResetUniversalIdPassword = new("RESET_UNIVERSAL_ID_PASSWORD");
-        public static readonly ServiceOperation ResetUniversalIdPasswordWithExpiry = new("RESET_UNIVERSAL_ID_PASSWORD_WITH_EXPIRY");
-        public static readonly ServiceOperation ResetUniversalIdPasswordAdvanced = new("RESET_UNIVERSAL_ID_PASSWORD_ADVANCED");
-        public static readonly ServiceOperation ResetUniversalIdPasswordAdvancedWithExpiry = new("RESET_UNIVERSAL_ID_PASSWORD_ADVANCED_WITH_EXPIRY");
-        public static readonly ServiceOperation SwitchToChildProfile = new("SWITCH_TO_CHILD_PROFILE");
-        public static readonly ServiceOperation SwitchToParentProfile = new("SWITCH_TO_PARENT_PROFILE");
-        public static readonly ServiceOperation DetachParent = new("DETACH_PARENT");
-        public static readonly ServiceOperation AttachParentWithIdentity = new("ATTACH_PARENT_WITH_IDENTITY");
-        public static readonly ServiceOperation AttachNonLoginUniversalId = new("ATTACH_NONLOGIN_UNIVERSAL");
-        public static readonly ServiceOperation UpdateUniversalIdLogin = new("UPDATE_UNIVERSAL_LOGIN");
-        public static readonly ServiceOperation GetIdentityStatus = new("GET_IDENTITY_STATUS");
+        public static readonly ServiceOperation Authenticate = new ServiceOperation("AUTHENTICATE");
+        public static readonly ServiceOperation Attach = new ServiceOperation("ATTACH");
+        public static readonly ServiceOperation Merge = new ServiceOperation("MERGE");
+        public static readonly ServiceOperation Detach = new ServiceOperation("DETACH");
+        public static readonly ServiceOperation GetServerVersion = new ServiceOperation("GET_SERVER_VERSION");
+        public static readonly ServiceOperation ResetEmailPassword = new ServiceOperation("RESET_EMAIL_PASSWORD");
+        public static readonly ServiceOperation ResetEmailPasswordWithExpiry = new ServiceOperation("RESET_EMAIL_PASSWORD_WITH_EXPIRY");
+        public static readonly ServiceOperation ResetEmailPasswordAdvanced = new ServiceOperation("RESET_EMAIL_PASSWORD_ADVANCED");
+        public static readonly ServiceOperation ResetEmailPasswordAdvancedWithExpiry = new ServiceOperation("RESET_EMAIL_PASSWORD_ADVANCED_WITH_EXPIRY");
+        public static readonly ServiceOperation ResetUniversalIdPassword = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD");
+        public static readonly ServiceOperation ResetUniversalIdPasswordWithExpiry = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD_WITH_EXPIRY");
+        public static readonly ServiceOperation ResetUniversalIdPasswordAdvanced = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD_ADVANCED");
+        public static readonly ServiceOperation ResetUniversalIdPasswordAdvancedWithExpiry = new ServiceOperation("RESET_UNIVERSAL_ID_PASSWORD_ADVANCED_WITH_EXPIRY");
+        public static readonly ServiceOperation SwitchToChildProfile = new ServiceOperation("SWITCH_TO_CHILD_PROFILE");
+        public static readonly ServiceOperation SwitchToParentProfile = new ServiceOperation("SWITCH_TO_PARENT_PROFILE");
+        public static readonly ServiceOperation DetachParent = new ServiceOperation("DETACH_PARENT");
+        public static readonly ServiceOperation AttachParentWithIdentity = new ServiceOperation("ATTACH_PARENT_WITH_IDENTITY");
+        public static readonly ServiceOperation AttachNonLoginUniversalId = new ServiceOperation("ATTACH_NONLOGIN_UNIVERSAL");
+        public static readonly ServiceOperation UpdateUniversalIdLogin = new ServiceOperation("UPDATE_UNIVERSAL_LOGIN");
+        public static readonly ServiceOperation GetIdentityStatus = new ServiceOperation("GET_IDENTITY_STATUS");
 
-        public static readonly ServiceOperation AttachBlockChain = new("ATTACH_BLOCKCHAIN_IDENTITY");
-        public static readonly ServiceOperation DetachBlockChain = new("DETACH_BLOCKCHAIN_IDENTITY");
-        public static readonly ServiceOperation GetBlockchainItems = new("GET_BLOCKCHAIN_ITEMS");
-        public static readonly ServiceOperation GetUniqs = new("GET_UNIQS");
+        public static readonly ServiceOperation AttachBlockChain = new ServiceOperation("ATTACH_BLOCKCHAIN_IDENTITY");
+        public static readonly ServiceOperation DetachBlockChain = new ServiceOperation("DETACH_BLOCKCHAIN_IDENTITY");
+        public static readonly ServiceOperation GetBlockchainItems = new ServiceOperation("GET_BLOCKCHAIN_ITEMS");
+        public static readonly ServiceOperation GetUniqs = new ServiceOperation("GET_UNIQS");
 
-        public static readonly ServiceOperation Create = new("CREATE");
-        public static readonly ServiceOperation CreateWithIndexedId = new("CREATE_WITH_INDEXED_ID");
-        public static readonly ServiceOperation Reset = new("RESET");
-        public static readonly ServiceOperation Read = new("READ");
-        public static readonly ServiceOperation ReadSingleton = new("READ_SINGLETON");
-        public static readonly ServiceOperation ReadByType = new("READ_BY_TYPE");
-        public static readonly ServiceOperation Verify = new("VERIFY");
-        public static readonly ServiceOperation ReadShared = new("READ_SHARED");
-        public static readonly ServiceOperation ReadSharedEntity = new("READ_SHARED_ENTITY");
-        public static readonly ServiceOperation UpdateEntityIndexedId = new("UPDATE_INDEXED_ID");
-        public static readonly ServiceOperation UpdateEntityOwnerAndAcl = new("UPDATE_ENTITY_OWNER_AND_ACL");
-        public static readonly ServiceOperation MakeSystemEntity = new("MAKE_SYSTEM_ENTITY");
+        public static readonly ServiceOperation Create = new ServiceOperation("CREATE");
+        public static readonly ServiceOperation CreateWithIndexedId = new ServiceOperation("CREATE_WITH_INDEXED_ID");
+        public static readonly ServiceOperation Reset = new ServiceOperation("RESET");
+        public static readonly ServiceOperation Read = new ServiceOperation("READ");
+        public static readonly ServiceOperation ReadSingleton = new ServiceOperation("READ_SINGLETON");
+        public static readonly ServiceOperation ReadByType = new ServiceOperation("READ_BY_TYPE");
+        public static readonly ServiceOperation Verify = new ServiceOperation("VERIFY");
+        public static readonly ServiceOperation ReadShared = new ServiceOperation("READ_SHARED");
+        public static readonly ServiceOperation ReadSharedEntity = new ServiceOperation("READ_SHARED_ENTITY");
+        public static readonly ServiceOperation UpdateEntityIndexedId = new ServiceOperation("UPDATE_INDEXED_ID");
+        public static readonly ServiceOperation UpdateEntityOwnerAndAcl = new ServiceOperation("UPDATE_ENTITY_OWNER_AND_ACL");
+        public static readonly ServiceOperation MakeSystemEntity = new ServiceOperation("MAKE_SYSTEM_ENTITY");
 
         // push notification
-        public static readonly ServiceOperation DeregisterAll = new("DEREGISTER_ALL");
-        public static readonly ServiceOperation Deregister = new("DEREGISTER");
-        public static readonly ServiceOperation Register = new("REGISTER");
-        public static readonly ServiceOperation SendSimple = new("SEND_SIMPLE");
-        public static readonly ServiceOperation SendRich = new("SEND_RICH");
-        public static readonly ServiceOperation SendRaw = new("SEND_RAW");
-        public static readonly ServiceOperation SendRawBatch = new("SEND_RAW_BATCH");
-        public static readonly ServiceOperation SendRawToGroup = new("SEND_RAW_TO_GROUP");
-        public static readonly ServiceOperation SendTemplatedToGroup = new("SEND_TEMPLATED_TO_GROUP");
-        public static readonly ServiceOperation SendNormalizedToGroup = new("SEND_NORMALIZED_TO_GROUP");
-        public static readonly ServiceOperation SendNormalized = new("SEND_NORMALIZED");
-        public static readonly ServiceOperation SendNormalizedBatch = new("SEND_NORMALIZED_BATCH");
-        public static readonly ServiceOperation ScheduleRichNotification = new("SCHEDULE_RICH_NOTIFICATION");
-        public static readonly ServiceOperation ScheduleNormalizedNotification = new("SCHEDULE_NORMALIZED_NOTIFICATION");
+        public static readonly ServiceOperation DeregisterAll = new ServiceOperation("DEREGISTER_ALL");
+        public static readonly ServiceOperation Deregister = new ServiceOperation("DEREGISTER");
+        public static readonly ServiceOperation Register = new ServiceOperation("REGISTER");
+        public static readonly ServiceOperation SendSimple = new ServiceOperation("SEND_SIMPLE");
+        public static readonly ServiceOperation SendRich = new ServiceOperation("SEND_RICH");
+        public static readonly ServiceOperation SendRaw = new ServiceOperation("SEND_RAW");
+        public static readonly ServiceOperation SendRawBatch = new ServiceOperation("SEND_RAW_BATCH");
+        public static readonly ServiceOperation SendRawToGroup = new ServiceOperation("SEND_RAW_TO_GROUP");
+        public static readonly ServiceOperation SendTemplatedToGroup = new ServiceOperation("SEND_TEMPLATED_TO_GROUP");
+        public static readonly ServiceOperation SendNormalizedToGroup = new ServiceOperation("SEND_NORMALIZED_TO_GROUP");
+        public static readonly ServiceOperation SendNormalized = new ServiceOperation("SEND_NORMALIZED");
+        public static readonly ServiceOperation SendNormalizedBatch = new ServiceOperation("SEND_NORMALIZED_BATCH");
+        public static readonly ServiceOperation ScheduleRichNotification = new ServiceOperation("SCHEDULE_RICH_NOTIFICATION");
+        public static readonly ServiceOperation ScheduleNormalizedNotification = new ServiceOperation("SCHEDULE_NORMALIZED_NOTIFICATION");
 
-        public static readonly ServiceOperation ScheduleRawNotification = new("SCHEDULE_RAW_NOTIFICATION");
+        public static readonly ServiceOperation ScheduleRawNotification = new ServiceOperation("SCHEDULE_RAW_NOTIFICATION");
 
-        public static readonly ServiceOperation FullReset = new("FULL_PLAYER_RESET");
-        public static readonly ServiceOperation DataReset = new("GAME_DATA_RESET");
+        public static readonly ServiceOperation FullReset = new ServiceOperation("FULL_PLAYER_RESET");
+        public static readonly ServiceOperation DataReset = new ServiceOperation("GAME_DATA_RESET");
 
-        public static readonly ServiceOperation ProcessStatistics = new("PROCESS_STATISTICS");
-        public static readonly ServiceOperation Update = new("UPDATE");
-        public static readonly ServiceOperation UpdateShared = new("UPDATE_SHARED");
-        public static readonly ServiceOperation UpdateAcl = new("UPDATE_ACL");
-        public static readonly ServiceOperation UpdateTimeToLive = new("UPDATE_TIME_TO_LIVE");
-        public static readonly ServiceOperation UpdatePartial = new("UPDATE_PARTIAL");
-        public static readonly ServiceOperation UpdateSingleton = new("UPDATE_SINGLETON");
-        public static readonly ServiceOperation Delete = new("DELETE");
-        public static readonly ServiceOperation DeleteSingleton = new("DELETE_SINGLETON");
-        public static readonly ServiceOperation UpdateSummary = new("UPDATE_SUMMARY");
-        public static readonly ServiceOperation UpdateSetMinimum = new("UPDATE_SET_MINIMUM");
-        public static readonly ServiceOperation UpdateIncrementToMaximum = new("UPDATE_INCREMENT_TO_MAXIMUM");
-        public static readonly ServiceOperation GetFriendProfileInfoForExternalId = new("GET_FRIEND_PROFILE_INFO_FOR_EXTERNAL_ID");
-        public static readonly ServiceOperation GetProfileInfoForCredential = new("GET_PROFILE_INFO_FOR_CREDENTIAL");
-        public static readonly ServiceOperation GetProfileInfoForCredentialIfExists = new("GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS");
-        public static readonly ServiceOperation GetProfileInfoForExternalAuthId = new("GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID");
-        public static readonly ServiceOperation GetProfileInfoForExternalAuthIdIfExists = new("GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS");
-        public static readonly ServiceOperation GetExternalIdForProfileId = new("GET_EXTERNAL_ID_FOR_PROFILE_ID");
-        public static readonly ServiceOperation FindPlayerByUniversalId = new("FIND_PLAYER_BY_UNIVERSAL_ID");
-        public static readonly ServiceOperation FindUserByExactUniversalId = new("FIND_USER_BY_EXACT_UNIVERSAL_ID");
-        public static readonly ServiceOperation FindUsersByNameStartingWith = new("FIND_USERS_BY_NAME_STARTING_WITH");
-        public static readonly ServiceOperation FindUsersByUniversalIdStartingWith = new("FIND_USERS_BY_UNIVERSAL_ID_STARTING_WITH");
-        public static readonly ServiceOperation ReadFriends = new("READ_FRIENDS");
-        public static readonly ServiceOperation ReadFriendEntity = new("READ_FRIEND_ENTITY");
-        public static readonly ServiceOperation ReadFriendsEntities = new("READ_FRIENDS_ENTITIES");
-        public static readonly ServiceOperation ReadFriendsWithApplication = new("READ_FRIENDS_WITH_APPLICATION");
-        public static readonly ServiceOperation ReadFriendPlayerState = new("READ_FRIEND_PLAYER_STATE");
-        public static readonly ServiceOperation GetSummaryDataForProfileId = new("GET_SUMMARY_DATA_FOR_PROFILE_ID");
-        public static readonly ServiceOperation FindPlayerByName = new("FIND_PLAYER_BY_NAME");
-        public static readonly ServiceOperation FindUsersByExactName = new("FIND_USERS_BY_EXACT_NAME");
-        public static readonly ServiceOperation FindUsersBySubstrName = new("FIND_USERS_BY_SUBSTR_NAME");
-        public static readonly ServiceOperation ListFriends = new("LIST_FRIENDS");
-        public static readonly ServiceOperation GetMySocialInfo = new("GET_MY_SOCIAL_INFO");
-        public static readonly ServiceOperation AddFriends = new("ADD_FRIENDS");
-        public static readonly ServiceOperation AddFriendsFromPlatform = new("ADD_FRIENDS_FROM_PLATFORM");
-        public static readonly ServiceOperation RemoveFriends = new("REMOVE_FRIENDS");
-        public static readonly ServiceOperation GetUsersOnlineStatus = new("GET_USERS_ONLINE_STATUS");
-        public static readonly ServiceOperation GetSocialLeaderboard = new("GET_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetSocialLeaderboardIfExists = new("GET_SOCIAL_LEADERBOARD_IF_EXISTS");
-        public static readonly ServiceOperation GetSocialLeaderboardByVersion = new("GET_SOCIAL_LEADERBOARD_BY_VERSION");
-        public static readonly ServiceOperation GetSocialLeaderboardByVersionIfExists = new("GET_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS");
-        public static readonly ServiceOperation GetMultiSocialLeaderboard = new("GET_MULTI_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetGlobalLeaderboard = new("GET_GLOBAL_LEADERBOARD");
-        public static readonly ServiceOperation GetGlobalLeaderboardPage = new("GET_GLOBAL_LEADERBOARD_PAGE");
-        public static readonly ServiceOperation GetGlobalLeaderboardPageIfExists = new("GET_GLOBAL_LEADERBOARD_PAGE_IF_EXISTS");
-        public static readonly ServiceOperation GetGlobalLeaderboardView = new("GET_GLOBAL_LEADERBOARD_VIEW");
-        public static readonly ServiceOperation GetGlobalLeaderboardViewIfExists = new("GET_GLOBAL_LEADERBOARD_VIEW_IF_EXISTS");
-        public static readonly ServiceOperation GetGlobalLeaderboardVersions = new("GET_GLOBAL_LEADERBOARD_VERSIONS");
-        public static readonly ServiceOperation PostScore = new("POST_SCORE");
-        public static readonly ServiceOperation PostScoreDynamic = new("POST_SCORE_DYNAMIC");
-        public static readonly ServiceOperation PostScoreDynamicUsingConfig = new("POST_SCORE_DYNAMIC_USING_CONFIG");
-        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboard = new("POST_GROUP_SCORE_DYNAMIC");
-        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboardUsingConfig = new("POST_GROUP_SCORE_DYNAMIC_USING_CONFIG");
-        public static readonly ServiceOperation RemovePlayerScore = new("REMOVE_PLAYER_SCORE");
-        public static readonly ServiceOperation GetCompletedTournament = new("GET_COMPLETED_TOURNAMENT");
-        public static readonly ServiceOperation RewardTournament = new("REWARD_TOURNAMENT");
-        public static readonly ServiceOperation GetGroupSocialLeaderboard = new("GET_GROUP_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetGroupSocialLeaderboardByVersion = new("GET_GROUP_SOCIAL_LEADERBOARD_BY_VERSION");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboard = new("GET_PLAYERS_SOCIAL_LEADERBOARD");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboardIfExists = new("GET_PLAYERS_SOCIAL_LEADERBOARD_IF_EXISTS");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersion = new("GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION");
-        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersionIfExists = new("GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS");
-        public static readonly ServiceOperation ListAllLeaderboards = new("LIST_ALL_LEADERBOARDS");
-        public static readonly ServiceOperation GetGlobalLeaderboardEntryCount = new("GET_GLOBAL_LEADERBOARD_ENTRY_COUNT");
-        public static readonly ServiceOperation GetPlayerScore = new("GET_PLAYER_SCORE");
-        public static readonly ServiceOperation GetPlayerScores = new("GET_PLAYER_SCORES");
-        public static readonly ServiceOperation GetPlayerScoresFromLeaderboards = new("GET_PLAYER_SCORES_FROM_LEADERBOARDS");
-        public static readonly ServiceOperation PostScoreToGroupLeaderboard = new("POST_GROUP_SCORE");
-        public static readonly ServiceOperation RemoveGroupScore = new("REMOVE_GROUP_SCORE");
-        public static readonly ServiceOperation GetGroupLeaderboardView = new("GET_GROUP_LEADERBOARD_VIEW");
+        public static readonly ServiceOperation ProcessStatistics = new ServiceOperation("PROCESS_STATISTICS");
+        public static readonly ServiceOperation Update = new ServiceOperation("UPDATE");
+        public static readonly ServiceOperation UpdateShared = new ServiceOperation("UPDATE_SHARED");
+        public static readonly ServiceOperation UpdateAcl = new ServiceOperation("UPDATE_ACL");
+        public static readonly ServiceOperation UpdateTimeToLive = new ServiceOperation("UPDATE_TIME_TO_LIVE");
+        public static readonly ServiceOperation UpdatePartial = new ServiceOperation("UPDATE_PARTIAL");
+        public static readonly ServiceOperation UpdateSingleton = new ServiceOperation("UPDATE_SINGLETON");
+        public static readonly ServiceOperation Delete = new ServiceOperation("DELETE");
+        public static readonly ServiceOperation DeleteSingleton = new ServiceOperation("DELETE_SINGLETON");
+        public static readonly ServiceOperation UpdateSummary = new ServiceOperation("UPDATE_SUMMARY");
+        public static readonly ServiceOperation UpdateSetMinimum = new ServiceOperation("UPDATE_SET_MINIMUM");
+        public static readonly ServiceOperation UpdateIncrementToMaximum = new ServiceOperation("UPDATE_INCREMENT_TO_MAXIMUM");
+        public static readonly ServiceOperation GetFriendProfileInfoForExternalId = new ServiceOperation("GET_FRIEND_PROFILE_INFO_FOR_EXTERNAL_ID");
+        public static readonly ServiceOperation GetProfileInfoForCredential = new ServiceOperation("GET_PROFILE_INFO_FOR_CREDENTIAL");
+        public static readonly ServiceOperation GetProfileInfoForCredentialIfExists = new ServiceOperation("GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS");
+        public static readonly ServiceOperation GetProfileInfoForExternalAuthId = new ServiceOperation("GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID");
+        public static readonly ServiceOperation GetProfileInfoForExternalAuthIdIfExists = new ServiceOperation("GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS");
+        public static readonly ServiceOperation GetExternalIdForProfileId = new ServiceOperation("GET_EXTERNAL_ID_FOR_PROFILE_ID");
+        public static readonly ServiceOperation FindPlayerByUniversalId = new ServiceOperation("FIND_PLAYER_BY_UNIVERSAL_ID");
+        public static readonly ServiceOperation FindUserByExactUniversalId = new ServiceOperation("FIND_USER_BY_EXACT_UNIVERSAL_ID");
+        public static readonly ServiceOperation FindUsersByNameStartingWith = new ServiceOperation("FIND_USERS_BY_NAME_STARTING_WITH");
+        public static readonly ServiceOperation FindUsersByUniversalIdStartingWith = new ServiceOperation("FIND_USERS_BY_UNIVERSAL_ID_STARTING_WITH");
+        public static readonly ServiceOperation ReadFriends = new ServiceOperation("READ_FRIENDS");
+        public static readonly ServiceOperation ReadFriendEntity = new ServiceOperation("READ_FRIEND_ENTITY");
+        public static readonly ServiceOperation ReadFriendsEntities = new ServiceOperation("READ_FRIENDS_ENTITIES");
+        public static readonly ServiceOperation ReadFriendsWithApplication = new ServiceOperation("READ_FRIENDS_WITH_APPLICATION");
+        public static readonly ServiceOperation ReadFriendPlayerState = new ServiceOperation("READ_FRIEND_PLAYER_STATE");
+        public static readonly ServiceOperation GetSummaryDataForProfileId = new ServiceOperation("GET_SUMMARY_DATA_FOR_PROFILE_ID");
+        public static readonly ServiceOperation FindPlayerByName = new ServiceOperation("FIND_PLAYER_BY_NAME");
+        public static readonly ServiceOperation FindUsersByExactName = new ServiceOperation("FIND_USERS_BY_EXACT_NAME");
+        public static readonly ServiceOperation FindUsersBySubstrName = new ServiceOperation("FIND_USERS_BY_SUBSTR_NAME");
+        public static readonly ServiceOperation ListFriends = new ServiceOperation("LIST_FRIENDS");
+        public static readonly ServiceOperation GetMySocialInfo = new ServiceOperation("GET_MY_SOCIAL_INFO");
+        public static readonly ServiceOperation AddFriends = new ServiceOperation("ADD_FRIENDS");
+        public static readonly ServiceOperation AddFriendsFromPlatform = new ServiceOperation("ADD_FRIENDS_FROM_PLATFORM");
+        public static readonly ServiceOperation RemoveFriends = new ServiceOperation("REMOVE_FRIENDS");
+        public static readonly ServiceOperation GetUsersOnlineStatus = new ServiceOperation("GET_USERS_ONLINE_STATUS");
+        public static readonly ServiceOperation GetSocialLeaderboard = new ServiceOperation("GET_SOCIAL_LEADERBOARD");
+        public static readonly ServiceOperation GetSocialLeaderboardIfExists = new ServiceOperation("GET_SOCIAL_LEADERBOARD_IF_EXISTS");
+        public static readonly ServiceOperation GetSocialLeaderboardByVersion = new ServiceOperation("GET_SOCIAL_LEADERBOARD_BY_VERSION");
+        public static readonly ServiceOperation GetSocialLeaderboardByVersionIfExists = new ServiceOperation("GET_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS");
+        public static readonly ServiceOperation GetMultiSocialLeaderboard = new ServiceOperation("GET_MULTI_SOCIAL_LEADERBOARD");
+        public static readonly ServiceOperation GetGlobalLeaderboard = new ServiceOperation("GET_GLOBAL_LEADERBOARD");
+        public static readonly ServiceOperation GetGlobalLeaderboardPage = new ServiceOperation("GET_GLOBAL_LEADERBOARD_PAGE");
+        public static readonly ServiceOperation GetGlobalLeaderboardPageIfExists = new ServiceOperation("GET_GLOBAL_LEADERBOARD_PAGE_IF_EXISTS");
+        public static readonly ServiceOperation GetGlobalLeaderboardView = new ServiceOperation("GET_GLOBAL_LEADERBOARD_VIEW");
+        public static readonly ServiceOperation GetGlobalLeaderboardViewIfExists = new ServiceOperation("GET_GLOBAL_LEADERBOARD_VIEW_IF_EXISTS");
+        public static readonly ServiceOperation GetGlobalLeaderboardVersions = new ServiceOperation("GET_GLOBAL_LEADERBOARD_VERSIONS");
+        public static readonly ServiceOperation PostScore = new ServiceOperation("POST_SCORE");
+        public static readonly ServiceOperation PostScoreDynamic = new ServiceOperation("POST_SCORE_DYNAMIC");
+        public static readonly ServiceOperation PostScoreDynamicUsingConfig = new ServiceOperation("POST_SCORE_DYNAMIC_USING_CONFIG");
+        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboard = new ServiceOperation("POST_GROUP_SCORE_DYNAMIC");
+        public static readonly ServiceOperation PostScoreToDynamicGroupLeaderboardUsingConfig = new ServiceOperation("POST_GROUP_SCORE_DYNAMIC_USING_CONFIG");
+        public static readonly ServiceOperation RemovePlayerScore = new ServiceOperation("REMOVE_PLAYER_SCORE");
+        public static readonly ServiceOperation GetCompletedTournament = new ServiceOperation("GET_COMPLETED_TOURNAMENT");
+        public static readonly ServiceOperation RewardTournament = new ServiceOperation("REWARD_TOURNAMENT");
+        public static readonly ServiceOperation GetGroupSocialLeaderboard = new ServiceOperation("GET_GROUP_SOCIAL_LEADERBOARD");
+        public static readonly ServiceOperation GetGroupSocialLeaderboardByVersion = new ServiceOperation("GET_GROUP_SOCIAL_LEADERBOARD_BY_VERSION");
+        public static readonly ServiceOperation GetPlayersSocialLeaderboard = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD");
+        public static readonly ServiceOperation GetPlayersSocialLeaderboardIfExists = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD_IF_EXISTS");
+        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersion = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION");
+        public static readonly ServiceOperation GetPlayersSocialLeaderboardByVersionIfExists = new ServiceOperation("GET_PLAYERS_SOCIAL_LEADERBOARD_BY_VERSION_IF_EXISTS");
+        public static readonly ServiceOperation ListAllLeaderboards = new ServiceOperation("LIST_ALL_LEADERBOARDS");
+        public static readonly ServiceOperation GetGlobalLeaderboardEntryCount = new ServiceOperation("GET_GLOBAL_LEADERBOARD_ENTRY_COUNT");
+        public static readonly ServiceOperation GetPlayerScore = new ServiceOperation("GET_PLAYER_SCORE");
+        public static readonly ServiceOperation GetPlayerScores = new ServiceOperation("GET_PLAYER_SCORES");
+        public static readonly ServiceOperation GetPlayerScoresFromLeaderboards = new ServiceOperation("GET_PLAYER_SCORES_FROM_LEADERBOARDS");
+        public static readonly ServiceOperation PostScoreToGroupLeaderboard = new ServiceOperation("POST_GROUP_SCORE");
+        public static readonly ServiceOperation RemoveGroupScore = new ServiceOperation("REMOVE_GROUP_SCORE");
+        public static readonly ServiceOperation GetGroupLeaderboardView = new ServiceOperation("GET_GROUP_LEADERBOARD_VIEW");
 
-        public static readonly ServiceOperation ReadFriendsPlayerState = new("READ_FRIEND_PLAYER_STATE");
+        public static readonly ServiceOperation ReadFriendsPlayerState = new ServiceOperation("READ_FRIEND_PLAYER_STATE");
 
-        public static readonly ServiceOperation InitThirdParty = new("initThirdParty");
-        public static readonly ServiceOperation PostThirdPartyLeaderboardScore = new("postThirdPartyLeaderboardScore");
-        public static readonly ServiceOperation IncrementThirdPartyLeaderboardScore = new("incrementThirdPartyLeaderboardScore");
-        public static readonly ServiceOperation LaunchAchievementUI = new("launchAchievementUI");
-        public static readonly ServiceOperation PostThirdPartyLeaderboardAchievement = new("postThirdPartyLeaderboardAchievement");
-        public static readonly ServiceOperation IsThirdPartyAchievementComplete = new("isThirdPartyAchievementComplete");
-        public static readonly ServiceOperation ResetThirdPartyAchievements = new("resetThirdPartyAchievements");
-        public static readonly ServiceOperation QueryThirdPartyAchievements = new("queryThirdPartyAchievements");
+        public static readonly ServiceOperation InitThirdParty = new ServiceOperation("initThirdParty");
+        public static readonly ServiceOperation PostThirdPartyLeaderboardScore = new ServiceOperation("postThirdPartyLeaderboardScore");
+        public static readonly ServiceOperation IncrementThirdPartyLeaderboardScore = new ServiceOperation("incrementThirdPartyLeaderboardScore");
+        public static readonly ServiceOperation LaunchAchievementUI = new ServiceOperation("launchAchievementUI");
+        public static readonly ServiceOperation PostThirdPartyLeaderboardAchievement = new ServiceOperation("postThirdPartyLeaderboardAchievement");
+        public static readonly ServiceOperation IsThirdPartyAchievementComplete = new ServiceOperation("isThirdPartyAchievementComplete");
+        public static readonly ServiceOperation ResetThirdPartyAchievements = new ServiceOperation("resetThirdPartyAchievements");
+        public static readonly ServiceOperation QueryThirdPartyAchievements = new ServiceOperation("queryThirdPartyAchievements");
 
-        public static readonly ServiceOperation GetInventory = new("GET_INVENTORY");
-        public static readonly ServiceOperation CashInReceipt = new("OP_CASH_IN_RECEIPT");
-        public static readonly ServiceOperation AwardVC = new("AWARD_VC");
-        public static readonly ServiceOperation ConsumePlayerVC = new("CONSUME_VC");
-        public static readonly ServiceOperation GetPlayerVC = new("GET_PLAYER_VC");
-        public static readonly ServiceOperation ResetPlayerVC = new("RESET_PLAYER_VC");
+        public static readonly ServiceOperation GetInventory = new ServiceOperation("GET_INVENTORY");
+        public static readonly ServiceOperation CashInReceipt = new ServiceOperation("OP_CASH_IN_RECEIPT");
+        public static readonly ServiceOperation AwardVC = new ServiceOperation("AWARD_VC");
+        public static readonly ServiceOperation ConsumePlayerVC = new ServiceOperation("CONSUME_VC");
+        public static readonly ServiceOperation GetPlayerVC = new ServiceOperation("GET_PLAYER_VC");
+        public static readonly ServiceOperation ResetPlayerVC = new ServiceOperation("RESET_PLAYER_VC");
 
-        public static readonly ServiceOperation AwardParentCurrency = new("AWARD_PARENT_VC");
-        public static readonly ServiceOperation ConsumeParentCurrency = new("CONSUME_PARENT_VC");
-        public static readonly ServiceOperation GetParentVC = new("GET_PARENT_VC");
-        public static readonly ServiceOperation ResetParentCurrency = new("RESET_PARENT_VC");
+        public static readonly ServiceOperation AwardParentCurrency = new ServiceOperation("AWARD_PARENT_VC");
+        public static readonly ServiceOperation ConsumeParentCurrency = new ServiceOperation("CONSUME_PARENT_VC");
+        public static readonly ServiceOperation GetParentVC = new ServiceOperation("GET_PARENT_VC");
+        public static readonly ServiceOperation ResetParentCurrency = new ServiceOperation("RESET_PARENT_VC");
 
-        public static readonly ServiceOperation GetPeerVC = new("GET_PEER_VC");
-        public static readonly ServiceOperation StartPurchase = new("START_PURCHASE");
-        public static readonly ServiceOperation FinalizePurchase = new("FINALIZE_PURCHASE");
-        public static readonly ServiceOperation RefreshPromotions = new("REFRESH_PROMOTIONS");
+        public static readonly ServiceOperation GetPeerVC = new ServiceOperation("GET_PEER_VC");
+        public static readonly ServiceOperation StartPurchase = new ServiceOperation("START_PURCHASE");
+        public static readonly ServiceOperation FinalizePurchase = new ServiceOperation("FINALIZE_PURCHASE");
+        public static readonly ServiceOperation RefreshPromotions = new ServiceOperation("REFRESH_PROMOTIONS");
 
-        public static readonly ServiceOperation Send = new("SEND");
-        public static readonly ServiceOperation SendToProfiles = new("SEND_EVENT_TO_PROFILES");
-        public static readonly ServiceOperation UpdateEventData = new("UPDATE_EVENT_DATA");
-        public static readonly ServiceOperation UpdateEventDataIfExists = new("UPDATE_EVENT_DATA_IF_EXISTS");
-        public static readonly ServiceOperation DeleteSent = new("DELETE_SENT");
-        public static readonly ServiceOperation DeleteIncoming = new("DELETE_INCOMING");
-        public static readonly ServiceOperation DeleteIncomingEvents = new("DELETE_INCOMING_EVENTS");
-        public static readonly ServiceOperation DeleteIncomingEventsOlderThan = new("DELETE_INCOMING_EVENTS_OLDER_THAN");
-        public static readonly ServiceOperation DeleteIncomingEventsByTypeOlderThan = new("DELETE_INCOMING_EVENTS_BY_TYPE_OLDER_THAN");
-        public static readonly ServiceOperation GetEvents = new("GET_EVENTS");
+        public static readonly ServiceOperation Send = new ServiceOperation("SEND");
+        public static readonly ServiceOperation SendToProfiles = new ServiceOperation("SEND_EVENT_TO_PROFILES");
+        public static readonly ServiceOperation UpdateEventData = new ServiceOperation("UPDATE_EVENT_DATA");
+        public static readonly ServiceOperation UpdateEventDataIfExists = new ServiceOperation("UPDATE_EVENT_DATA_IF_EXISTS");
+        public static readonly ServiceOperation DeleteSent = new ServiceOperation("DELETE_SENT");
+        public static readonly ServiceOperation DeleteIncoming = new ServiceOperation("DELETE_INCOMING");
+        public static readonly ServiceOperation DeleteIncomingEvents = new ServiceOperation("DELETE_INCOMING_EVENTS");
+        public static readonly ServiceOperation DeleteIncomingEventsOlderThan = new ServiceOperation("DELETE_INCOMING_EVENTS_OLDER_THAN");
+        public static readonly ServiceOperation DeleteIncomingEventsByTypeOlderThan = new ServiceOperation("DELETE_INCOMING_EVENTS_BY_TYPE_OLDER_THAN");
+        public static readonly ServiceOperation GetEvents = new ServiceOperation("GET_EVENTS");
 
-        public static readonly ServiceOperation UpdateIncrement = new("UPDATE_INCREMENT");
-        public static readonly ServiceOperation ReadNextXpLevel = new("READ_NEXT_XPLEVEL");
-        public static readonly ServiceOperation ReadXpLevels = new("READ_XP_LEVELS");
-        public static readonly ServiceOperation SetXpPoints = new("SET_XPPOINTS");
-        public static readonly ServiceOperation ReadSubset = new("READ_SUBSET");
+        public static readonly ServiceOperation UpdateIncrement = new ServiceOperation("UPDATE_INCREMENT");
+        public static readonly ServiceOperation ReadNextXpLevel = new ServiceOperation("READ_NEXT_XPLEVEL");
+        public static readonly ServiceOperation ReadXpLevels = new ServiceOperation("READ_XP_LEVELS");
+        public static readonly ServiceOperation SetXpPoints = new ServiceOperation("SET_XPPOINTS");
+        public static readonly ServiceOperation ReadSubset = new ServiceOperation("READ_SUBSET");
 
         //GlobalFile
-        public static readonly ServiceOperation GetFileInfo = new("GET_FILE_INFO");
-        public static readonly ServiceOperation GetFileInfoSimple = new("GET_FILE_INFO_SIMPLE");
-        public static readonly ServiceOperation GetGlobalCDNUrl = new("GET_GLOBAL_CDN_URL");
-        public static readonly ServiceOperation GetGlobalFileList = new("GET_GLOBAL_FILE_LIST");
+        public static readonly ServiceOperation GetFileInfo = new ServiceOperation("GET_FILE_INFO");
+        public static readonly ServiceOperation GetFileInfoSimple = new ServiceOperation("GET_FILE_INFO_SIMPLE");
+        public static readonly ServiceOperation GetGlobalCDNUrl = new ServiceOperation("GET_GLOBAL_CDN_URL");
+        public static readonly ServiceOperation GetGlobalFileList = new ServiceOperation("GET_GLOBAL_FILE_LIST");
 
-        public static readonly ServiceOperation Run = new("RUN");
-        public static readonly ServiceOperation Tweet = new("TWEET");
+        public static readonly ServiceOperation Run = new ServiceOperation("RUN");
+        public static readonly ServiceOperation Tweet = new ServiceOperation("TWEET");
 
-        public static readonly ServiceOperation AwardAchievements = new("AWARD_ACHIEVEMENTS");
-        public static readonly ServiceOperation ReadAchievements = new("READ_ACHIEVEMENTS");
-        public static readonly ServiceOperation ReadAchievedAchievements = new("READ_ACHIEVED_ACHIEVEMENTS");
+        public static readonly ServiceOperation AwardAchievements = new ServiceOperation("AWARD_ACHIEVEMENTS");
+        public static readonly ServiceOperation ReadAchievements = new ServiceOperation("READ_ACHIEVEMENTS");
+        public static readonly ServiceOperation ReadAchievedAchievements = new ServiceOperation("READ_ACHIEVED_ACHIEVEMENTS");
 
-        public static readonly ServiceOperation SetPlayerRating = new("SET_PLAYER_RATING");
-        public static readonly ServiceOperation ResetPlayerRating = new("RESET_PLAYER_RATING");
-        public static readonly ServiceOperation IncrementPlayerRating = new("INCREMENT_PLAYER_RATING");
-        public static readonly ServiceOperation DecrementPlayerRating = new("DECREMENT_PLAYER_RATING");
-        public static readonly ServiceOperation ShieldOn = new("SHIELD_ON");
-        public static readonly ServiceOperation ShieldOnFor = new("SHIELD_ON_FOR");
-        public static readonly ServiceOperation ShieldOff = new("SHIELD_OFF");
-        public static readonly ServiceOperation IncrementShieldOnFor = new("INCREMENT_SHIELD_ON_FOR");
-        public static readonly ServiceOperation GetShieldExpiry = new("GET_SHIELD_EXPIRY");
-        public static readonly ServiceOperation FindPlayers = new("FIND_PLAYERS");
-        public static readonly ServiceOperation FindPlayersUsingFilter = new("FIND_PLAYERS_USING_FILTER");
+        public static readonly ServiceOperation SetPlayerRating = new ServiceOperation("SET_PLAYER_RATING");
+        public static readonly ServiceOperation ResetPlayerRating = new ServiceOperation("RESET_PLAYER_RATING");
+        public static readonly ServiceOperation IncrementPlayerRating = new ServiceOperation("INCREMENT_PLAYER_RATING");
+        public static readonly ServiceOperation DecrementPlayerRating = new ServiceOperation("DECREMENT_PLAYER_RATING");
+        public static readonly ServiceOperation ShieldOn = new ServiceOperation("SHIELD_ON");
+        public static readonly ServiceOperation ShieldOnFor = new ServiceOperation("SHIELD_ON_FOR");
+        public static readonly ServiceOperation ShieldOff = new ServiceOperation("SHIELD_OFF");
+        public static readonly ServiceOperation IncrementShieldOnFor = new ServiceOperation("INCREMENT_SHIELD_ON_FOR");
+        public static readonly ServiceOperation GetShieldExpiry = new ServiceOperation("GET_SHIELD_EXPIRY");
+        public static readonly ServiceOperation FindPlayers = new ServiceOperation("FIND_PLAYERS");
+        public static readonly ServiceOperation FindPlayersUsingFilter = new ServiceOperation("FIND_PLAYERS_USING_FILTER");
 
-        public static readonly ServiceOperation SubmitTurn = new("SUBMIT_TURN");
-        public static readonly ServiceOperation UpdateMatchSummary = new("UPDATE_SUMMARY");
-        public static readonly ServiceOperation UpdateMatchStateCurrentTurn = new("UPDATE_MATCH_STATE_CURRENT_TURN");
-        public static readonly ServiceOperation Abandon = new("ABANDON");
-        public static readonly ServiceOperation AbandonMatchWithSummaryData = new("ABANDON_MATCH_WITH_SUMMARY_DATA");
-        public static readonly ServiceOperation CompleteMatchWithSummaryData = new("COMPLETE_MATCH_WITH_SUMMARY_DATA");
-        public static readonly ServiceOperation Complete = new("COMPLETE");
-        public static readonly ServiceOperation ReadMatch = new("READ_MATCH");
-        public static readonly ServiceOperation ReadMatchHistory = new("READ_MATCH_HISTORY");
-        public static readonly ServiceOperation FindMatches = new("FIND_MATCHES");
-        public static readonly ServiceOperation FindMatchesCompleted = new("FIND_MATCHES_COMPLETED");
-        public static readonly ServiceOperation DeleteMatch = new("DELETE_MATCH");
+        public static readonly ServiceOperation SubmitTurn = new ServiceOperation("SUBMIT_TURN");
+        public static readonly ServiceOperation UpdateMatchSummary = new ServiceOperation("UPDATE_SUMMARY");
+        public static readonly ServiceOperation UpdateMatchStateCurrentTurn = new ServiceOperation("UPDATE_MATCH_STATE_CURRENT_TURN");
+        public static readonly ServiceOperation Abandon = new ServiceOperation("ABANDON");
+        public static readonly ServiceOperation AbandonMatchWithSummaryData = new ServiceOperation("ABANDON_MATCH_WITH_SUMMARY_DATA");
+        public static readonly ServiceOperation CompleteMatchWithSummaryData = new ServiceOperation("COMPLETE_MATCH_WITH_SUMMARY_DATA");
+        public static readonly ServiceOperation Complete = new ServiceOperation("COMPLETE");
+        public static readonly ServiceOperation ReadMatch = new ServiceOperation("READ_MATCH");
+        public static readonly ServiceOperation ReadMatchHistory = new ServiceOperation("READ_MATCH_HISTORY");
+        public static readonly ServiceOperation FindMatches = new ServiceOperation("FIND_MATCHES");
+        public static readonly ServiceOperation FindMatchesCompleted = new ServiceOperation("FIND_MATCHES_COMPLETED");
+        public static readonly ServiceOperation DeleteMatch = new ServiceOperation("DELETE_MATCH");
 
-        public static readonly ServiceOperation LastUploadStatus = new("LAST_UPLOAD_STATUS");
+        public static readonly ServiceOperation LastUploadStatus = new ServiceOperation("LAST_UPLOAD_STATUS");
 
-        public static readonly ServiceOperation ReadQuests = new("READ_QUESTS");
-        public static readonly ServiceOperation ReadCompletedQuests = new("READ_COMPLETED_QUESTS");
-        public static readonly ServiceOperation ReadInProgressQuests = new("READ_IN_PROGRESS_QUESTS");
-        public static readonly ServiceOperation ReadNotStartedQuests = new("READ_NOT_STARTED_QUESTS");
-        public static readonly ServiceOperation ReadQuestsWithStatus = new("READ_QUESTS_WITH_STATUS");
-        public static readonly ServiceOperation ReadQuestsWithBasicPercentage = new("READ_QUESTS_WITH_BASIC_PERCENTAGE");
-        public static readonly ServiceOperation ReadQuestsWithComplexPercentage = new("READ_QUESTS_WITH_COMPLEX_PERCENTAGE");
-        public static readonly ServiceOperation ReadQuestsByCategory = new("READ_QUESTS_BY_CATEGORY");
-        public static readonly ServiceOperation ResetMilestones = new("RESET_MILESTONES");
+        public static readonly ServiceOperation ReadQuests = new ServiceOperation("READ_QUESTS");
+        public static readonly ServiceOperation ReadCompletedQuests = new ServiceOperation("READ_COMPLETED_QUESTS");
+        public static readonly ServiceOperation ReadInProgressQuests = new ServiceOperation("READ_IN_PROGRESS_QUESTS");
+        public static readonly ServiceOperation ReadNotStartedQuests = new ServiceOperation("READ_NOT_STARTED_QUESTS");
+        public static readonly ServiceOperation ReadQuestsWithStatus = new ServiceOperation("READ_QUESTS_WITH_STATUS");
+        public static readonly ServiceOperation ReadQuestsWithBasicPercentage = new ServiceOperation("READ_QUESTS_WITH_BASIC_PERCENTAGE");
+        public static readonly ServiceOperation ReadQuestsWithComplexPercentage = new ServiceOperation("READ_QUESTS_WITH_COMPLEX_PERCENTAGE");
+        public static readonly ServiceOperation ReadQuestsByCategory = new ServiceOperation("READ_QUESTS_BY_CATEGORY");
+        public static readonly ServiceOperation ResetMilestones = new ServiceOperation("RESET_MILESTONES");
 
-        public static readonly ServiceOperation ReadForCategory = new("READ_FOR_CATEGORY");
+        public static readonly ServiceOperation ReadForCategory = new ServiceOperation("READ_FOR_CATEGORY");
 
-        public static readonly ServiceOperation ReadMilestones = new("READ_MILESTONES");
-        public static readonly ServiceOperation ReadMilestonesByCategory = new("READ_MILESTONES_BY_CATEGORY");
+        public static readonly ServiceOperation ReadMilestones = new ServiceOperation("READ_MILESTONES");
+        public static readonly ServiceOperation ReadMilestonesByCategory = new ServiceOperation("READ_MILESTONES_BY_CATEGORY");
 
-        public static readonly ServiceOperation ReadCompletedMilestones = new("READ_COMPLETED_MILESTONES");
-        public static readonly ServiceOperation ReadInProgressMilestones = new("READ_IN_PROGRESS_MILESTONES");
+        public static readonly ServiceOperation ReadCompletedMilestones = new ServiceOperation("READ_COMPLETED_MILESTONES");
+        public static readonly ServiceOperation ReadInProgressMilestones = new ServiceOperation("READ_IN_PROGRESS_MILESTONES");
 
-        public static readonly ServiceOperation Trigger = new("TRIGGER");
-        public static readonly ServiceOperation TriggerMultiple = new("TRIGGER_MULTIPLE");
+        public static readonly ServiceOperation Trigger = new ServiceOperation("TRIGGER");
+        public static readonly ServiceOperation TriggerMultiple = new ServiceOperation("TRIGGER_MULTIPLE");
 
-        public static readonly ServiceOperation Logout = new("LOGOUT");
+        public static readonly ServiceOperation Logout = new ServiceOperation("LOGOUT");
 
-        public static readonly ServiceOperation StartMatch = new("START_MATCH");
-        public static readonly ServiceOperation CancelMatch = new("CANCEL_MATCH");
-        public static readonly ServiceOperation CompleteMatch = new("COMPLETE_MATCH");
-        public static readonly ServiceOperation EnableMatchMaking = new("ENABLE_FOR_MATCH");
-        public static readonly ServiceOperation DisableMatchMaking = new("DISABLE_FOR_MATCH");
-        public static readonly ServiceOperation UpdateName = new("UPDATE_NAME");
+        public static readonly ServiceOperation StartMatch = new ServiceOperation("START_MATCH");
+        public static readonly ServiceOperation CancelMatch = new ServiceOperation("CANCEL_MATCH");
+        public static readonly ServiceOperation CompleteMatch = new ServiceOperation("COMPLETE_MATCH");
+        public static readonly ServiceOperation EnableMatchMaking = new ServiceOperation("ENABLE_FOR_MATCH");
+        public static readonly ServiceOperation DisableMatchMaking = new ServiceOperation("DISABLE_FOR_MATCH");
+        public static readonly ServiceOperation UpdateName = new ServiceOperation("UPDATE_NAME");
 
-        public static readonly ServiceOperation StartStream = new("START_STREAM");
-        public static readonly ServiceOperation ReadStream = new("READ_STREAM");
-        public static readonly ServiceOperation EndStream = new("END_STREAM");
-        public static readonly ServiceOperation DeleteStream = new("DELETE_STREAM");
-        public static readonly ServiceOperation AddEvent = new("ADD_EVENT");
-        public static readonly ServiceOperation ProtectStreamUntil = new("PROTECT_STREAM_UNTIL");
+        public static readonly ServiceOperation StartStream = new ServiceOperation("START_STREAM");
+        public static readonly ServiceOperation ReadStream = new ServiceOperation("READ_STREAM");
+        public static readonly ServiceOperation EndStream = new ServiceOperation("END_STREAM");
+        public static readonly ServiceOperation DeleteStream = new ServiceOperation("DELETE_STREAM");
+        public static readonly ServiceOperation AddEvent = new ServiceOperation("ADD_EVENT");
+        public static readonly ServiceOperation ProtectStreamUntil = new ServiceOperation("PROTECT_STREAM_UNTIL");
 
-        public static readonly ServiceOperation GetStreamSummariesForInitiatingPlayer = new("GET_STREAM_SUMMARIES_FOR_INITIATING_PLAYER");
-        public static readonly ServiceOperation GetStreamSummariesForTargetPlayer = new("GET_STREAM_SUMMARIES_FOR_TARGET_PLAYER");
-        public static readonly ServiceOperation GetRecentStreamsForInitiatingPlayer = new("GET_RECENT_STREAMS_FOR_INITIATING_PLAYER");
-        public static readonly ServiceOperation GetRecentStreamsForTargetPlayer = new("GET_RECENT_STREAMS_FOR_TARGET_PLAYER");
+        public static readonly ServiceOperation GetStreamSummariesForInitiatingPlayer = new ServiceOperation("GET_STREAM_SUMMARIES_FOR_INITIATING_PLAYER");
+        public static readonly ServiceOperation GetStreamSummariesForTargetPlayer = new ServiceOperation("GET_STREAM_SUMMARIES_FOR_TARGET_PLAYER");
+        public static readonly ServiceOperation GetRecentStreamsForInitiatingPlayer = new ServiceOperation("GET_RECENT_STREAMS_FOR_INITIATING_PLAYER");
+        public static readonly ServiceOperation GetRecentStreamsForTargetPlayer = new ServiceOperation("GET_RECENT_STREAMS_FOR_TARGET_PLAYER");
 
-        public static readonly ServiceOperation GetUserInfo = new("GET_USER_INFO");
-        public static readonly ServiceOperation InitializeTransaction = new("INITIALIZE_TRANSACTION");
-        public static readonly ServiceOperation FinalizeTransaction = new("FINALIZE_TRANSACTION");
+        public static readonly ServiceOperation GetUserInfo = new ServiceOperation("GET_USER_INFO");
+        public static readonly ServiceOperation InitializeTransaction = new ServiceOperation("INITIALIZE_TRANSACTION");
+        public static readonly ServiceOperation FinalizeTransaction = new ServiceOperation("FINALIZE_TRANSACTION");
 
-        public static readonly ServiceOperation CachePurchasePayloadContext = new("CACHE_PURCHASE_PAYLOAD_CONTEXT");
-        public static readonly ServiceOperation VerifyPurchase = new("VERIFY_PURCHASE");
-        public static readonly ServiceOperation StartSteamTransaction = new("START_STEAM_TRANSACTION");
-        public static readonly ServiceOperation FinalizeSteamTransaction = new("FINALIZE_STEAM_TRANSACTION");
-        public static readonly ServiceOperation VerifyMicrosoftReceipt = new("VERIFY_MICROSOFT_RECEIPT");
-        public static readonly ServiceOperation EligiblePromotions = new("ELIGIBLE_PROMOTIONS");
+        public static readonly ServiceOperation CachePurchasePayloadContext = new ServiceOperation("CACHE_PURCHASE_PAYLOAD_CONTEXT");
+        public static readonly ServiceOperation VerifyPurchase = new ServiceOperation("VERIFY_PURCHASE");
+        public static readonly ServiceOperation StartSteamTransaction = new ServiceOperation("START_STEAM_TRANSACTION");
+        public static readonly ServiceOperation FinalizeSteamTransaction = new ServiceOperation("FINALIZE_STEAM_TRANSACTION");
+        public static readonly ServiceOperation VerifyMicrosoftReceipt = new ServiceOperation("VERIFY_MICROSOFT_RECEIPT");
+        public static readonly ServiceOperation EligiblePromotions = new ServiceOperation("ELIGIBLE_PROMOTIONS");
 
-        public static readonly ServiceOperation ReadSharedEntitiesList = new("READ_SHARED_ENTITIES_LIST");
-        public static readonly ServiceOperation GetList = new("GET_LIST");
-        public static readonly ServiceOperation GetListByIndexedId = new("GET_LIST_BY_INDEXED_ID");
-        public static readonly ServiceOperation GetListCount = new("GET_LIST_COUNT");
-        public static readonly ServiceOperation GetPage = new("GET_PAGE");
-        public static readonly ServiceOperation GetPageOffset = new("GET_PAGE_BY_OFFSET");
-        public static readonly ServiceOperation IncrementGlobalEntityData = new("INCREMENT_GLOBAL_ENTITY_DATA");
-        public static readonly ServiceOperation GetRandomEntitiesMatching = new("GET_RANDOM_ENTITIES_MATCHING");
-        public static readonly ServiceOperation IncrementUserEntityData = new("INCREMENT_USER_ENTITY_DATA");
-        public static readonly ServiceOperation IncrementSharedUserEntityData = new("INCREMENT_SHARED_USER_ENTITY_DATA");
+        public static readonly ServiceOperation ReadSharedEntitiesList = new ServiceOperation("READ_SHARED_ENTITIES_LIST");
+        public static readonly ServiceOperation GetList = new ServiceOperation("GET_LIST");
+        public static readonly ServiceOperation GetListByIndexedId = new ServiceOperation("GET_LIST_BY_INDEXED_ID");
+        public static readonly ServiceOperation GetListCount = new ServiceOperation("GET_LIST_COUNT");
+        public static readonly ServiceOperation GetPage = new ServiceOperation("GET_PAGE");
+        public static readonly ServiceOperation GetPageOffset = new ServiceOperation("GET_PAGE_BY_OFFSET");
+        public static readonly ServiceOperation IncrementGlobalEntityData = new ServiceOperation("INCREMENT_GLOBAL_ENTITY_DATA");
+        public static readonly ServiceOperation GetRandomEntitiesMatching = new ServiceOperation("GET_RANDOM_ENTITIES_MATCHING");
+        public static readonly ServiceOperation IncrementUserEntityData = new ServiceOperation("INCREMENT_USER_ENTITY_DATA");
+        public static readonly ServiceOperation IncrementSharedUserEntityData = new ServiceOperation("INCREMENT_SHARED_USER_ENTITY_DATA");
 
-        public static readonly ServiceOperation UpdatePictureUrl = new("UPDATE_PICTURE_URL");
-        public static readonly ServiceOperation UpdateContactEmail = new("UPDATE_CONTACT_EMAIL");
-        public static readonly ServiceOperation UpdateLanguageCode = new("UPDATE_LANGUAGE_CODE");
-        public static readonly ServiceOperation UpdateTimeZoneOffset = new("UPDATE_TIMEZONE_OFFSET");
-        public static readonly ServiceOperation SetUserStatus = new("SET_USER_STATUS");        
-        public static readonly ServiceOperation GetUserStatus = new("GET_USER_STATUS");
-        public static readonly ServiceOperation ClearUserStatus = new("CLEAR_USER_STATUS");
-        public static readonly ServiceOperation ExtendUserStatus = new("EXTEND_USER_STATUS");
-        public static readonly ServiceOperation GetAttributes = new("GET_ATTRIBUTES");
-        public static readonly ServiceOperation UpdateAttributes = new("UPDATE_ATTRIBUTES");
-        public static readonly ServiceOperation RemoveAttributes = new("REMOVE_ATTRIBUTES");
-        public static readonly ServiceOperation GetChildProfiles = new("GET_CHILD_PROFILES");
-        public static readonly ServiceOperation GetIdentities = new("GET_IDENTITIES");
-        public static readonly ServiceOperation GetExpiredIdentities = new("GET_EXPIRED_IDENTITIES");
-        public static readonly ServiceOperation RefreshIdentity = new("REFRESH_IDENTITY");
-        public static readonly ServiceOperation ChangeEmailIdentity = new("CHANGE_EMAIL_IDENTITY");
+        public static readonly ServiceOperation UpdatePictureUrl = new ServiceOperation("UPDATE_PICTURE_URL");
+        public static readonly ServiceOperation UpdateContactEmail = new ServiceOperation("UPDATE_CONTACT_EMAIL");
+        public static readonly ServiceOperation UpdateLanguageCode = new ServiceOperation("UPDATE_LANGUAGE_CODE");
+        public static readonly ServiceOperation UpdateTimeZoneOffset = new ServiceOperation("UPDATE_TIMEZONE_OFFSET");
+        public static readonly ServiceOperation SetUserStatus = new ServiceOperation("SET_USER_STATUS");        
+        public static readonly ServiceOperation GetUserStatus = new ServiceOperation("GET_USER_STATUS");
+        public static readonly ServiceOperation ClearUserStatus = new ServiceOperation("CLEAR_USER_STATUS");
+        public static readonly ServiceOperation ExtendUserStatus = new ServiceOperation("EXTEND_USER_STATUS");
+        public static readonly ServiceOperation GetAttributes = new ServiceOperation("GET_ATTRIBUTES");
+        public static readonly ServiceOperation UpdateAttributes = new ServiceOperation("UPDATE_ATTRIBUTES");
+        public static readonly ServiceOperation RemoveAttributes = new ServiceOperation("REMOVE_ATTRIBUTES");
+        public static readonly ServiceOperation GetChildProfiles = new ServiceOperation("GET_CHILD_PROFILES");
+        public static readonly ServiceOperation GetIdentities = new ServiceOperation("GET_IDENTITIES");
+        public static readonly ServiceOperation GetExpiredIdentities = new ServiceOperation("GET_EXPIRED_IDENTITIES");
+        public static readonly ServiceOperation RefreshIdentity = new ServiceOperation("REFRESH_IDENTITY");
+        public static readonly ServiceOperation ChangeEmailIdentity = new ServiceOperation("CHANGE_EMAIL_IDENTITY");
 
-        public static readonly ServiceOperation FbConfirmPurchase = new("FB_CONFIRM_PURCHASE");
-        public static readonly ServiceOperation GooglePlayConfirmPurchase = new("CONFIRM_GOOGLEPLAY_PURCHASE");
+        public static readonly ServiceOperation FbConfirmPurchase = new ServiceOperation("FB_CONFIRM_PURCHASE");
+        public static readonly ServiceOperation GooglePlayConfirmPurchase = new ServiceOperation("CONFIRM_GOOGLEPLAY_PURCHASE");
 
-        public static readonly ServiceOperation ReadProperties = new("READ_PROPERTIES");
-        public static readonly ServiceOperation ReadSelectedProperties = new("READ_SELECTED_PROPERTIES");
-        public static readonly ServiceOperation ReadPropertiesInCategories = new("READ_PROPERTIES_IN_CATEGORIES");
+        public static readonly ServiceOperation ReadProperties = new ServiceOperation("READ_PROPERTIES");
+        public static readonly ServiceOperation ReadSelectedProperties = new ServiceOperation("READ_SELECTED_PROPERTIES");
+        public static readonly ServiceOperation ReadPropertiesInCategories = new ServiceOperation("READ_PROPERTIES_IN_CATEGORIES");
 
-        public static readonly ServiceOperation GetUpdatedFiles = new("GET_UPDATED_FILES");
-        public static readonly ServiceOperation GetFileList = new("GET_FILE_LIST");
+        public static readonly ServiceOperation GetUpdatedFiles = new ServiceOperation("GET_UPDATED_FILES");
+        public static readonly ServiceOperation GetFileList = new ServiceOperation("GET_FILE_LIST");
 
-        public static readonly ServiceOperation ScheduleCloudScript = new("SCHEDULE_CLOUD_SCRIPT");
-        public static readonly ServiceOperation GetScheduledCloudScripts = new("GET_SCHEDULED_CLOUD_SCRIPTS");
-        public static readonly ServiceOperation GetRunningOrQueuedCloudScripts = new("GET_RUNNING_OR_QUEUED_CLOUD_SCRIPTS");
-        public static readonly ServiceOperation RunParentScript = new("RUN_PARENT_SCRIPT");
-        public static readonly ServiceOperation CancelScheduledScript = new("CANCEL_SCHEDULED_SCRIPT");
-        public static readonly ServiceOperation RunPeerScript = new("RUN_PEER_SCRIPT");
-        public static readonly ServiceOperation RunPeerScriptAsync = new("RUN_PEER_SCRIPT_ASYNC");
+        public static readonly ServiceOperation ScheduleCloudScript = new ServiceOperation("SCHEDULE_CLOUD_SCRIPT");
+        public static readonly ServiceOperation GetScheduledCloudScripts = new ServiceOperation("GET_SCHEDULED_CLOUD_SCRIPTS");
+        public static readonly ServiceOperation GetRunningOrQueuedCloudScripts = new ServiceOperation("GET_RUNNING_OR_QUEUED_CLOUD_SCRIPTS");
+        public static readonly ServiceOperation RunParentScript = new ServiceOperation("RUN_PARENT_SCRIPT");
+        public static readonly ServiceOperation CancelScheduledScript = new ServiceOperation("CANCEL_SCHEDULED_SCRIPT");
+        public static readonly ServiceOperation RunPeerScript = new ServiceOperation("RUN_PEER_SCRIPT");
+        public static readonly ServiceOperation RunPeerScriptAsync = new ServiceOperation("RUN_PEER_SCRIPT_ASYNC");
 
         //RedemptionCode
-        public static readonly ServiceOperation GetRedeemedCodes = new("GET_REDEEMED_CODES");
-        public static readonly ServiceOperation RedeemCode = new("REDEEM_CODE");
+        public static readonly ServiceOperation GetRedeemedCodes = new ServiceOperation("GET_REDEEMED_CODES");
+        public static readonly ServiceOperation RedeemCode = new ServiceOperation("REDEEM_CODE");
 
         //DataStream
-        public static readonly ServiceOperation CustomPageEvent = new("CUSTOM_PAGE_EVENT");
-        public static readonly ServiceOperation CustomScreenEvent = new("CUSTOM_SCREEN_EVENT");
-        public static readonly ServiceOperation CustomTrackEvent = new("CUSTOM_TRACK_EVENT");
-        public static readonly ServiceOperation SubmitCrashReport = new("SEND_CRASH_REPORT");
+        public static readonly ServiceOperation CustomPageEvent = new ServiceOperation("CUSTOM_PAGE_EVENT");
+        public static readonly ServiceOperation CustomScreenEvent = new ServiceOperation("CUSTOM_SCREEN_EVENT");
+        public static readonly ServiceOperation CustomTrackEvent = new ServiceOperation("CUSTOM_TRACK_EVENT");
+        public static readonly ServiceOperation SubmitCrashReport = new ServiceOperation("SEND_CRASH_REPORT");
 
         //Profanity
-        public static readonly ServiceOperation ProfanityCheck = new("PROFANITY_CHECK");
-        public static readonly ServiceOperation ProfanityReplaceText = new("PROFANITY_REPLACE_TEXT");
-        public static readonly ServiceOperation ProfanityIdentifyBadWords = new("PROFANITY_IDENTIFY_BAD_WORDS");
+        public static readonly ServiceOperation ProfanityCheck = new ServiceOperation("PROFANITY_CHECK");
+        public static readonly ServiceOperation ProfanityReplaceText = new ServiceOperation("PROFANITY_REPLACE_TEXT");
+        public static readonly ServiceOperation ProfanityIdentifyBadWords = new ServiceOperation("PROFANITY_IDENTIFY_BAD_WORDS");
 
         //file upload
-        public static readonly ServiceOperation PrepareUserUpload = new("PREPARE_USER_UPLOAD");
-        public static readonly ServiceOperation ListUserFiles = new("LIST_USER_FILES");
-        public static readonly ServiceOperation DeleteUserFile = new("DELETE_USER_FILE");
-        public static readonly ServiceOperation DeleteUserFiles = new("DELETE_USER_FILES");
-        public static readonly ServiceOperation GetCdnUrl = new("GET_CDN_URL");
+        public static readonly ServiceOperation PrepareUserUpload = new ServiceOperation("PREPARE_USER_UPLOAD");
+        public static readonly ServiceOperation ListUserFiles = new ServiceOperation("LIST_USER_FILES");
+        public static readonly ServiceOperation DeleteUserFile = new ServiceOperation("DELETE_USER_FILE");
+        public static readonly ServiceOperation DeleteUserFiles = new ServiceOperation("DELETE_USER_FILES");
+        public static readonly ServiceOperation GetCdnUrl = new ServiceOperation("GET_CDN_URL");
 
         //group
-        public static readonly ServiceOperation AcceptGroupInvitation = new("ACCEPT_GROUP_INVITATION");
-        public static readonly ServiceOperation AddGroupMember = new("ADD_GROUP_MEMBER");
-        public static readonly ServiceOperation ApproveGroupJoinRequest = new("APPROVE_GROUP_JOIN_REQUEST");
-        public static readonly ServiceOperation AutoJoinGroup = new("AUTO_JOIN_GROUP");
-        public static readonly ServiceOperation AutoJoinGroupMulti = new("AUTO_JOIN_GROUP_MULTI");
-        public static readonly ServiceOperation CancelGroupInvitation = new("CANCEL_GROUP_INVITATION");
-        public static readonly ServiceOperation DeleteGroupJoinRequest = new("DELETE_GROUP_JOIN_REQUEST");
-        public static readonly ServiceOperation CreateGroup = new("CREATE_GROUP");
-        public static readonly ServiceOperation CreateGroupEntity = new("CREATE_GROUP_ENTITY");
-        public static readonly ServiceOperation DeleteGroup = new("DELETE_GROUP");
-        public static readonly ServiceOperation DeleteGroupEntity = new("DELETE_GROUP_ENTITY");
-        public static readonly ServiceOperation DeleteGroupMemeber = new("DELETE_MEMBER_FROM_GROUP");
-        public static readonly ServiceOperation GetMyGroups = new("GET_MY_GROUPS");
-        public static readonly ServiceOperation IncrementGroupData = new("INCREMENT_GROUP_DATA");
-        public static readonly ServiceOperation IncrementGroupEntityData = new("INCREMENT_GROUP_ENTITY_DATA");
-        public static readonly ServiceOperation InviteGroupMember = new("INVITE_GROUP_MEMBER");
-        public static readonly ServiceOperation JoinGroup = new("JOIN_GROUP");
-        public static readonly ServiceOperation LeaveGroup = new("LEAVE_GROUP");
-        public static readonly ServiceOperation ListGroupsPage = new("LIST_GROUPS_PAGE");
-        public static readonly ServiceOperation ListGroupsPageByOffset = new("LIST_GROUPS_PAGE_BY_OFFSET");
-        public static readonly ServiceOperation ListGroupsWithMember = new("LIST_GROUPS_WITH_MEMBER");
-        public static readonly ServiceOperation ReadGroup = new("READ_GROUP");
-        public static readonly ServiceOperation ReadGroupData = new("READ_GROUP_DATA");
-        public static readonly ServiceOperation ReadGroupEntitiesPage = new("READ_GROUP_ENTITIES_PAGE");
-        public static readonly ServiceOperation ReadGroupEntitiesPageByOffset = new("READ_GROUP_ENTITIES_PAGE_BY_OFFSET");
-        public static readonly ServiceOperation ReadGroupEntity = new("READ_GROUP_ENTITY");
-        public static readonly ServiceOperation ReadGroupMembers = new("READ_GROUP_MEMBERS");
-        public static readonly ServiceOperation RejectGroupInvitation = new("REJECT_GROUP_INVITATION");
-        public static readonly ServiceOperation RejectGroupJoinRequest = new("REJECT_GROUP_JOIN_REQUEST");
-        public static readonly ServiceOperation RemoveGroupMember = new("REMOVE_GROUP_MEMBER");
-        public static readonly ServiceOperation UpdateGroupData = new("UPDATE_GROUP_DATA");
-        public static readonly ServiceOperation UpdateGroupEntity = new("UPDATE_GROUP_ENTITY_DATA");
-        public static readonly ServiceOperation UpdateGroupMember = new("UPDATE_GROUP_MEMBER");
-        public static readonly ServiceOperation UpdateGroupACL = new("UPDATE_GROUP_ACL");
-        public static readonly ServiceOperation UpdateGroupEntityACL = new("UPDATE_GROUP_ENTITY_ACL");
-        public static readonly ServiceOperation UpdateGroupName = new("UPDATE_GROUP_NAME");
-        public static readonly ServiceOperation SetGroupOpen = new("SET_GROUP_OPEN");
-        public static readonly ServiceOperation GetRandomGroupsMatching = new("GET_RANDOM_GROUPS_MATCHING");
-        public static readonly ServiceOperation UpdateGroupSummaryData = new("UPDATE_GROUP_SUMMARY_DATA");
+        public static readonly ServiceOperation AcceptGroupInvitation = new ServiceOperation("ACCEPT_GROUP_INVITATION");
+        public static readonly ServiceOperation AddGroupMember = new ServiceOperation("ADD_GROUP_MEMBER");
+        public static readonly ServiceOperation ApproveGroupJoinRequest = new ServiceOperation("APPROVE_GROUP_JOIN_REQUEST");
+        public static readonly ServiceOperation AutoJoinGroup = new ServiceOperation("AUTO_JOIN_GROUP");
+        public static readonly ServiceOperation AutoJoinGroupMulti = new ServiceOperation("AUTO_JOIN_GROUP_MULTI");
+        public static readonly ServiceOperation CancelGroupInvitation = new ServiceOperation("CANCEL_GROUP_INVITATION");
+        public static readonly ServiceOperation DeleteGroupJoinRequest = new ServiceOperation("DELETE_GROUP_JOIN_REQUEST");
+        public static readonly ServiceOperation CreateGroup = new ServiceOperation("CREATE_GROUP");
+        public static readonly ServiceOperation CreateGroupEntity = new ServiceOperation("CREATE_GROUP_ENTITY");
+        public static readonly ServiceOperation DeleteGroup = new ServiceOperation("DELETE_GROUP");
+        public static readonly ServiceOperation DeleteGroupEntity = new ServiceOperation("DELETE_GROUP_ENTITY");
+        public static readonly ServiceOperation DeleteGroupMemeber = new ServiceOperation("DELETE_MEMBER_FROM_GROUP");
+        public static readonly ServiceOperation GetMyGroups = new ServiceOperation("GET_MY_GROUPS");
+        public static readonly ServiceOperation IncrementGroupData = new ServiceOperation("INCREMENT_GROUP_DATA");
+        public static readonly ServiceOperation IncrementGroupEntityData = new ServiceOperation("INCREMENT_GROUP_ENTITY_DATA");
+        public static readonly ServiceOperation InviteGroupMember = new ServiceOperation("INVITE_GROUP_MEMBER");
+        public static readonly ServiceOperation JoinGroup = new ServiceOperation("JOIN_GROUP");
+        public static readonly ServiceOperation LeaveGroup = new ServiceOperation("LEAVE_GROUP");
+        public static readonly ServiceOperation ListGroupsPage = new ServiceOperation("LIST_GROUPS_PAGE");
+        public static readonly ServiceOperation ListGroupsPageByOffset = new ServiceOperation("LIST_GROUPS_PAGE_BY_OFFSET");
+        public static readonly ServiceOperation ListGroupsWithMember = new ServiceOperation("LIST_GROUPS_WITH_MEMBER");
+        public static readonly ServiceOperation ReadGroup = new ServiceOperation("READ_GROUP");
+        public static readonly ServiceOperation ReadGroupData = new ServiceOperation("READ_GROUP_DATA");
+        public static readonly ServiceOperation ReadGroupEntitiesPage = new ServiceOperation("READ_GROUP_ENTITIES_PAGE");
+        public static readonly ServiceOperation ReadGroupEntitiesPageByOffset = new ServiceOperation("READ_GROUP_ENTITIES_PAGE_BY_OFFSET");
+        public static readonly ServiceOperation ReadGroupEntity = new ServiceOperation("READ_GROUP_ENTITY");
+        public static readonly ServiceOperation ReadGroupMembers = new ServiceOperation("READ_GROUP_MEMBERS");
+        public static readonly ServiceOperation RejectGroupInvitation = new ServiceOperation("REJECT_GROUP_INVITATION");
+        public static readonly ServiceOperation RejectGroupJoinRequest = new ServiceOperation("REJECT_GROUP_JOIN_REQUEST");
+        public static readonly ServiceOperation RemoveGroupMember = new ServiceOperation("REMOVE_GROUP_MEMBER");
+        public static readonly ServiceOperation UpdateGroupData = new ServiceOperation("UPDATE_GROUP_DATA");
+        public static readonly ServiceOperation UpdateGroupEntity = new ServiceOperation("UPDATE_GROUP_ENTITY_DATA");
+        public static readonly ServiceOperation UpdateGroupMember = new ServiceOperation("UPDATE_GROUP_MEMBER");
+        public static readonly ServiceOperation UpdateGroupACL = new ServiceOperation("UPDATE_GROUP_ACL");
+        public static readonly ServiceOperation UpdateGroupEntityACL = new ServiceOperation("UPDATE_GROUP_ENTITY_ACL");
+        public static readonly ServiceOperation UpdateGroupName = new ServiceOperation("UPDATE_GROUP_NAME");
+        public static readonly ServiceOperation SetGroupOpen = new ServiceOperation("SET_GROUP_OPEN");
+        public static readonly ServiceOperation GetRandomGroupsMatching = new ServiceOperation("GET_RANDOM_GROUPS_MATCHING");
+        public static readonly ServiceOperation UpdateGroupSummaryData = new ServiceOperation("UPDATE_GROUP_SUMMARY_DATA");
 
         //mail
-        public static readonly ServiceOperation SendBasicEmail = new("SEND_BASIC_EMAIL");
-        public static readonly ServiceOperation SendAdvancedEmail = new("SEND_ADVANCED_EMAIL");
-        public static readonly ServiceOperation SendAdvancedEmailByAddress = new("SEND_ADVANCED_EMAIL_BY_ADDRESS");
-        public static readonly ServiceOperation SendAdvancedEmailByAddresses = new("SEND_ADVANCED_EMAIL_BY_ADDRESSES");
+        public static readonly ServiceOperation SendBasicEmail = new ServiceOperation("SEND_BASIC_EMAIL");
+        public static readonly ServiceOperation SendAdvancedEmail = new ServiceOperation("SEND_ADVANCED_EMAIL");
+        public static readonly ServiceOperation SendAdvancedEmailByAddress = new ServiceOperation("SEND_ADVANCED_EMAIL_BY_ADDRESS");
+        public static readonly ServiceOperation SendAdvancedEmailByAddresses = new ServiceOperation("SEND_ADVANCED_EMAIL_BY_ADDRESSES");
 
         //peer
-        public static readonly ServiceOperation AttachPeerProfile = new("ATTACH_PEER_PROFILE");
-        public static readonly ServiceOperation DetachPeer = new("DETACH_PEER");
-        public static readonly ServiceOperation GetPeerProfiles = new("GET_PEER_PROFILES");
+        public static readonly ServiceOperation AttachPeerProfile = new ServiceOperation("ATTACH_PEER_PROFILE");
+        public static readonly ServiceOperation DetachPeer = new ServiceOperation("DETACH_PEER");
+        public static readonly ServiceOperation GetPeerProfiles = new ServiceOperation("GET_PEER_PROFILES");
 
         //presence
-        public static readonly ServiceOperation ForcePush = new("FORCE_PUSH");
-        public static readonly ServiceOperation GetPresenceOfFriends = new("GET_PRESENCE_OF_FRIENDS");
-        public static readonly ServiceOperation GetPresenceOfGroup = new("GET_PRESENCE_OF_GROUP");
-        public static readonly ServiceOperation GetPresenceOfUsers = new("GET_PRESENCE_OF_USERS");
-        public static readonly ServiceOperation RegisterListenersForFriends = new("REGISTER_LISTENERS_FOR_FRIENDS");
-        public static readonly ServiceOperation RegisterListenersForGroup = new("REGISTER_LISTENERS_FOR_GROUP");
-        public static readonly ServiceOperation RegisterListenersForProfiles = new("REGISTER_LISTENERS_FOR_PROFILES");
-        public static readonly ServiceOperation SetVisibility = new("SET_VISIBILITY");
-        public static readonly ServiceOperation StopListening = new("STOP_LISTENING");
-        public static readonly ServiceOperation UpdateActivity = new("UPDATE_ACTIVITY");
+        public static readonly ServiceOperation ForcePush = new ServiceOperation("FORCE_PUSH");
+        public static readonly ServiceOperation GetPresenceOfFriends = new ServiceOperation("GET_PRESENCE_OF_FRIENDS");
+        public static readonly ServiceOperation GetPresenceOfGroup = new ServiceOperation("GET_PRESENCE_OF_GROUP");
+        public static readonly ServiceOperation GetPresenceOfUsers = new ServiceOperation("GET_PRESENCE_OF_USERS");
+        public static readonly ServiceOperation RegisterListenersForFriends = new ServiceOperation("REGISTER_LISTENERS_FOR_FRIENDS");
+        public static readonly ServiceOperation RegisterListenersForGroup = new ServiceOperation("REGISTER_LISTENERS_FOR_GROUP");
+        public static readonly ServiceOperation RegisterListenersForProfiles = new ServiceOperation("REGISTER_LISTENERS_FOR_PROFILES");
+        public static readonly ServiceOperation SetVisibility = new ServiceOperation("SET_VISIBILITY");
+        public static readonly ServiceOperation StopListening = new ServiceOperation("STOP_LISTENING");
+        public static readonly ServiceOperation UpdateActivity = new ServiceOperation("UPDATE_ACTIVITY");
 
         //tournament
-        public static readonly ServiceOperation GetTournamentStatus = new("GET_TOURNAMENT_STATUS");
-        public static readonly ServiceOperation GetDivisionInfo = new("GET_DIVISION_INFO");
-        public static readonly ServiceOperation GetMyDivisions = new("GET_MY_DIVISIONS");
-        public static readonly ServiceOperation JoinDivision= new("JOIN_DIVISION");
-        public static readonly ServiceOperation JoinTournament = new("JOIN_TOURNAMENT");
-        public static readonly ServiceOperation LeaveDivisionInstance = new("LEAVE_DIVISION_INSTANCE");
-        public static readonly ServiceOperation LeaveTournament = new("LEAVE_TOURNAMENT");
-        public static readonly ServiceOperation PostTournamentScore = new("POST_TOURNAMENT_SCORE");
-        public static readonly ServiceOperation PostTournamentScoreWithResults = new("POST_TOURNAMENT_SCORE_WITH_RESULTS");
-        public static readonly ServiceOperation ViewCurrentReward = new("VIEW_CURRENT_REWARD");
-        public static readonly ServiceOperation ViewReward = new("VIEW_REWARD");
-        public static readonly ServiceOperation ClaimTournamentReward = new("CLAIM_TOURNAMENT_REWARD");
-        public static readonly ServiceOperation PostGroupTournamentScoreWithResults = new("POST_GROUP_TOURNAMENT_SCORE_WITH_RESULTS");
-        public static readonly ServiceOperation GetGroupDivisionInfo = new("GET_GROUP_DIVISION_INFO");
-        public static readonly ServiceOperation GetGroupDivisions = new("GET_GROUP_DIVISIONS");
-        public static readonly ServiceOperation GetGroupTournamentStatus = new("GET_GROUP_TOURNAMENT_STATUS");
-        public static readonly ServiceOperation JoinGroupDivision = new("JOIN_GROUP_DIVISION");
-        public static readonly ServiceOperation JoinGroupTournament = new("JOIN_GROUP_TOURNAMENT");
-        public static readonly ServiceOperation LeaveGroupTournament = new("LEAVE_GROUP_TOURNAMENT");
-        public static readonly ServiceOperation LeaveGroupDivisionInstance = new("LEAVE_GROUP_DIVISION_INSTANCE");
-        public static readonly ServiceOperation PostGroupTournamentScore = new("POST_GROUP_TOURNAMENT_SCORE");
+        public static readonly ServiceOperation GetTournamentStatus = new ServiceOperation("GET_TOURNAMENT_STATUS");
+        public static readonly ServiceOperation GetDivisionInfo = new ServiceOperation("GET_DIVISION_INFO");
+        public static readonly ServiceOperation GetMyDivisions = new ServiceOperation("GET_MY_DIVISIONS");
+        public static readonly ServiceOperation JoinDivision= new ServiceOperation("JOIN_DIVISION");
+        public static readonly ServiceOperation JoinTournament = new ServiceOperation("JOIN_TOURNAMENT");
+        public static readonly ServiceOperation LeaveDivisionInstance = new ServiceOperation("LEAVE_DIVISION_INSTANCE");
+        public static readonly ServiceOperation LeaveTournament = new ServiceOperation("LEAVE_TOURNAMENT");
+        public static readonly ServiceOperation PostTournamentScore = new ServiceOperation("POST_TOURNAMENT_SCORE");
+        public static readonly ServiceOperation PostTournamentScoreWithResults = new ServiceOperation("POST_TOURNAMENT_SCORE_WITH_RESULTS");
+        public static readonly ServiceOperation ViewCurrentReward = new ServiceOperation("VIEW_CURRENT_REWARD");
+        public static readonly ServiceOperation ViewReward = new ServiceOperation("VIEW_REWARD");
+        public static readonly ServiceOperation ClaimTournamentReward = new ServiceOperation("CLAIM_TOURNAMENT_REWARD");
+        public static readonly ServiceOperation PostGroupTournamentScoreWithResults = new ServiceOperation("POST_GROUP_TOURNAMENT_SCORE_WITH_RESULTS");
+        public static readonly ServiceOperation GetGroupDivisionInfo = new ServiceOperation("GET_GROUP_DIVISION_INFO");
+        public static readonly ServiceOperation GetGroupDivisions = new ServiceOperation("GET_GROUP_DIVISIONS");
+        public static readonly ServiceOperation GetGroupTournamentStatus = new ServiceOperation("GET_GROUP_TOURNAMENT_STATUS");
+        public static readonly ServiceOperation JoinGroupDivision = new ServiceOperation("JOIN_GROUP_DIVISION");
+        public static readonly ServiceOperation JoinGroupTournament = new ServiceOperation("JOIN_GROUP_TOURNAMENT");
+        public static readonly ServiceOperation LeaveGroupTournament = new ServiceOperation("LEAVE_GROUP_TOURNAMENT");
+        public static readonly ServiceOperation LeaveGroupDivisionInstance = new ServiceOperation("LEAVE_GROUP_DIVISION_INSTANCE");
+        public static readonly ServiceOperation PostGroupTournamentScore = new ServiceOperation("POST_GROUP_TOURNAMENT_SCORE");
 
         // rtt
-        public static readonly ServiceOperation RequestClientConnection = new("REQUEST_CLIENT_CONNECTION");
+        public static readonly ServiceOperation RequestClientConnection = new ServiceOperation("REQUEST_CLIENT_CONNECTION");
 
         // chat
-        public static readonly ServiceOperation ChannelConnect = new("CHANNEL_CONNECT");
-        public static readonly ServiceOperation ChannelDisconnect = new("CHANNEL_DISCONNECT");
-        public static readonly ServiceOperation DeleteChatMessage = new("DELETE_CHAT_MESSAGE");
-        public static readonly ServiceOperation GetChannelId = new("GET_CHANNEL_ID");
-        public static readonly ServiceOperation GetChannelInfo = new("GET_CHANNEL_INFO");
-        public static readonly ServiceOperation GetChatMessage = new("GET_CHAT_MESSAGE");
-        public static readonly ServiceOperation GetRecentChatMessages = new("GET_RECENT_CHAT_MESSAGES");
-        public static readonly ServiceOperation GetSubscribedChannels = new("GET_SUBSCRIBED_CHANNELS");
-        public static readonly ServiceOperation PostChatMessage = new("POST_CHAT_MESSAGE");
-        public static readonly ServiceOperation PostChatMessageSimple = new("POST_CHAT_MESSAGE_SIMPLE");
-        public static readonly ServiceOperation UpdateChatMessage = new("UPDATE_CHAT_MESSAGE");
+        public static readonly ServiceOperation ChannelConnect = new ServiceOperation("CHANNEL_CONNECT");
+        public static readonly ServiceOperation ChannelDisconnect = new ServiceOperation("CHANNEL_DISCONNECT");
+        public static readonly ServiceOperation DeleteChatMessage = new ServiceOperation("DELETE_CHAT_MESSAGE");
+        public static readonly ServiceOperation GetChannelId = new ServiceOperation("GET_CHANNEL_ID");
+        public static readonly ServiceOperation GetChannelInfo = new ServiceOperation("GET_CHANNEL_INFO");
+        public static readonly ServiceOperation GetChatMessage = new ServiceOperation("GET_CHAT_MESSAGE");
+        public static readonly ServiceOperation GetRecentChatMessages = new ServiceOperation("GET_RECENT_CHAT_MESSAGES");
+        public static readonly ServiceOperation GetSubscribedChannels = new ServiceOperation("GET_SUBSCRIBED_CHANNELS");
+        public static readonly ServiceOperation PostChatMessage = new ServiceOperation("POST_CHAT_MESSAGE");
+        public static readonly ServiceOperation PostChatMessageSimple = new ServiceOperation("POST_CHAT_MESSAGE_SIMPLE");
+        public static readonly ServiceOperation UpdateChatMessage = new ServiceOperation("UPDATE_CHAT_MESSAGE");
 
         // messaging 
-        public static readonly ServiceOperation DeleteMessages = new("DELETE_MESSAGES");
-        public static readonly ServiceOperation GetMessageBoxes = new("GET_MESSAGE_BOXES");
-        public static readonly ServiceOperation GetMessageCounts = new("GET_MESSAGE_COUNTS");
-        public static readonly ServiceOperation GetMessages = new("GET_MESSAGES");
-        public static readonly ServiceOperation GetMessagesPage = new("GET_MESSAGES_PAGE");
-        public static readonly ServiceOperation GetMessagesPageOffset = new("GET_MESSAGES_PAGE_OFFSET");
-        public static readonly ServiceOperation MarkMessagesRead = new("MARK_MESSAGES_READ");
-        public static readonly ServiceOperation SendMessage = new("SEND_MESSAGE");
-        public static readonly ServiceOperation SendMessageSimple = new("SEND_MESSAGE_SIMPLE");
+        public static readonly ServiceOperation DeleteMessages = new ServiceOperation("DELETE_MESSAGES");
+        public static readonly ServiceOperation GetMessageBoxes = new ServiceOperation("GET_MESSAGE_BOXES");
+        public static readonly ServiceOperation GetMessageCounts = new ServiceOperation("GET_MESSAGE_COUNTS");
+        public static readonly ServiceOperation GetMessages = new ServiceOperation("GET_MESSAGES");
+        public static readonly ServiceOperation GetMessagesPage = new ServiceOperation("GET_MESSAGES_PAGE");
+        public static readonly ServiceOperation GetMessagesPageOffset = new ServiceOperation("GET_MESSAGES_PAGE_OFFSET");
+        public static readonly ServiceOperation MarkMessagesRead = new ServiceOperation("MARK_MESSAGES_READ");
+        public static readonly ServiceOperation SendMessage = new ServiceOperation("SEND_MESSAGE");
+        public static readonly ServiceOperation SendMessageSimple = new ServiceOperation("SEND_MESSAGE_SIMPLE");
 
         // lobby
-        public static readonly ServiceOperation FindLobby = new("FIND_LOBBY");
-        public static readonly ServiceOperation FindLobbyWithPingData = new("FIND_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation CreateLobby = new("CREATE_LOBBY");
-        public static readonly ServiceOperation CreateLobbyWithPingData = new("CREATE_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation FindOrCreateLobby = new("FIND_OR_CREATE_LOBBY");
-        public static readonly ServiceOperation FindOrCreateLobbyWithPingData = new("FIND_OR_CREATE_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation GetLobbyData = new("GET_LOBBY_DATA");
-        public static readonly ServiceOperation UpdateReady = new("UPDATE_READY");
-        public static readonly ServiceOperation UpdateSettings = new("UPDATE_SETTINGS");
-        public static readonly ServiceOperation SwitchTeam = new("SWITCH_TEAM");
-        public static readonly ServiceOperation SendSignal = new("SEND_SIGNAL");
-        public static readonly ServiceOperation JoinLobby = new("JOIN_LOBBY");
-        public static readonly ServiceOperation JoinLobbyWithPingData = new("JOIN_LOBBY_WITH_PING_DATA");
-        public static readonly ServiceOperation LeaveLobby = new("LEAVE_LOBBY");
-        public static readonly ServiceOperation RemoveMember = new("REMOVE_MEMBER");
-        public static readonly ServiceOperation CancelFindRequest = new("CANCEL_FIND_REQUEST");
-        public static readonly ServiceOperation GetRegionsForLobbies = new("GET_REGIONS_FOR_LOBBIES");
-        public static readonly ServiceOperation GetLobbyInstances = new("GET_LOBBY_INSTANCES");
-        public static readonly ServiceOperation GetLobbyInstancesWithPingData = new("GET_LOBBY_INSTANCES_WITH_PING_DATA");
+        public static readonly ServiceOperation FindLobby = new ServiceOperation("FIND_LOBBY");
+        public static readonly ServiceOperation FindLobbyWithPingData = new ServiceOperation("FIND_LOBBY_WITH_PING_DATA");
+        public static readonly ServiceOperation CreateLobby = new ServiceOperation("CREATE_LOBBY");
+        public static readonly ServiceOperation CreateLobbyWithPingData = new ServiceOperation("CREATE_LOBBY_WITH_PING_DATA");
+        public static readonly ServiceOperation FindOrCreateLobby = new ServiceOperation("FIND_OR_CREATE_LOBBY");
+        public static readonly ServiceOperation FindOrCreateLobbyWithPingData = new ServiceOperation("FIND_OR_CREATE_LOBBY_WITH_PING_DATA");
+        public static readonly ServiceOperation GetLobbyData = new ServiceOperation("GET_LOBBY_DATA");
+        public static readonly ServiceOperation UpdateReady = new ServiceOperation("UPDATE_READY");
+        public static readonly ServiceOperation UpdateSettings = new ServiceOperation("UPDATE_SETTINGS");
+        public static readonly ServiceOperation SwitchTeam = new ServiceOperation("SWITCH_TEAM");
+        public static readonly ServiceOperation SendSignal = new ServiceOperation("SEND_SIGNAL");
+        public static readonly ServiceOperation JoinLobby = new ServiceOperation("JOIN_LOBBY");
+        public static readonly ServiceOperation JoinLobbyWithPingData = new ServiceOperation("JOIN_LOBBY_WITH_PING_DATA");
+        public static readonly ServiceOperation LeaveLobby = new ServiceOperation("LEAVE_LOBBY");
+        public static readonly ServiceOperation RemoveMember = new ServiceOperation("REMOVE_MEMBER");
+        public static readonly ServiceOperation CancelFindRequest = new ServiceOperation("CANCEL_FIND_REQUEST");
+        public static readonly ServiceOperation GetRegionsForLobbies = new ServiceOperation("GET_REGIONS_FOR_LOBBIES");
+        public static readonly ServiceOperation GetLobbyInstances = new ServiceOperation("GET_LOBBY_INSTANCES");
+        public static readonly ServiceOperation GetLobbyInstancesWithPingData = new ServiceOperation("GET_LOBBY_INSTANCES_WITH_PING_DATA");
 
         
         //ItemCatalog
-        public static readonly ServiceOperation GetCatalogItemDefinition = new("GET_CATALOG_ITEM_DEFINITION");
-        public static readonly ServiceOperation GetCatalogItemsPage = new("GET_CATALOG_ITEMS_PAGE");
-        public static readonly ServiceOperation GetCatalogItemsPageOffset = new("GET_CATALOG_ITEMS_PAGE_OFFSET");
+        public static readonly ServiceOperation GetCatalogItemDefinition = new ServiceOperation("GET_CATALOG_ITEM_DEFINITION");
+        public static readonly ServiceOperation GetCatalogItemsPage = new ServiceOperation("GET_CATALOG_ITEMS_PAGE");
+        public static readonly ServiceOperation GetCatalogItemsPageOffset = new ServiceOperation("GET_CATALOG_ITEMS_PAGE_OFFSET");
 
         //CustomEntity
 
-        public static readonly ServiceOperation DeleteEntities = new("DELETE_ENTITIES");
-        public static readonly ServiceOperation CreateCustomEntity = new("CREATE_ENTITY");
-        public static readonly ServiceOperation GetCustomEntityPage = new("GET_PAGE");
-        public static readonly ServiceOperation GetCustomEntityPageOffset = new("GET_ENTITY_PAGE_OFFSET");
-        public static readonly ServiceOperation GetEntityPage = new("GET_ENTITY_PAGE");
-        public static readonly ServiceOperation ReadCustomEntity = new("READ_ENTITY");
-        public static readonly ServiceOperation IncrementData = new("INCREMENT_DATA");
-        public static readonly ServiceOperation IncrementSingletonData = new("INCREMENT_SINGLETON_DATA");
-        public static readonly ServiceOperation UpdateCustomEntity = new("UPDATE_ENTITY");
-        public static readonly ServiceOperation UpdateCustomEntityFields = new("UPDATE_ENTITY_FIELDS");
-        public static readonly ServiceOperation UpdateCustomEntityFieldsShards = new("UPDATE_ENTITY_FIELDS_SHARDED");
-        public static readonly ServiceOperation DeleteCustomEntity = new("DELETE_ENTITY");
-        public static readonly ServiceOperation GetCount = new("GET_COUNT");
-        public static readonly ServiceOperation UpdateSingletonFields = new("UPDATE_SINGLETON_FIELDS");
+        public static readonly ServiceOperation DeleteEntities = new ServiceOperation("DELETE_ENTITIES");
+        public static readonly ServiceOperation CreateCustomEntity = new ServiceOperation("CREATE_ENTITY");
+        public static readonly ServiceOperation GetCustomEntityPage = new ServiceOperation("GET_PAGE");
+        public static readonly ServiceOperation GetCustomEntityPageOffset = new ServiceOperation("GET_ENTITY_PAGE_OFFSET");
+        public static readonly ServiceOperation GetEntityPage = new ServiceOperation("GET_ENTITY_PAGE");
+        public static readonly ServiceOperation ReadCustomEntity = new ServiceOperation("READ_ENTITY");
+        public static readonly ServiceOperation IncrementData = new ServiceOperation("INCREMENT_DATA");
+        public static readonly ServiceOperation IncrementSingletonData = new ServiceOperation("INCREMENT_SINGLETON_DATA");
+        public static readonly ServiceOperation UpdateCustomEntity = new ServiceOperation("UPDATE_ENTITY");
+        public static readonly ServiceOperation UpdateCustomEntityFields = new ServiceOperation("UPDATE_ENTITY_FIELDS");
+        public static readonly ServiceOperation UpdateCustomEntityFieldsShards = new ServiceOperation("UPDATE_ENTITY_FIELDS_SHARDED");
+        public static readonly ServiceOperation DeleteCustomEntity = new ServiceOperation("DELETE_ENTITY");
+        public static readonly ServiceOperation GetCount = new ServiceOperation("GET_COUNT");
+        public static readonly ServiceOperation UpdateSingletonFields = new ServiceOperation("UPDATE_SINGLETON_FIELDS");
 
         //UserItemsService
 
-        public static readonly ServiceOperation AwardUserItem = new("AWARD_USER_ITEM");
-        public static readonly ServiceOperation DropUserItem = new("DROP_USER_ITEM");
-        public static readonly ServiceOperation GetUserItemsPage = new("GET_USER_ITEMS_PAGE");
-        public static readonly ServiceOperation GetUserItemsPageOffset = new("GET_USER_ITEMS_PAGE_OFFSET");
-        public static readonly ServiceOperation GetUserItem = new("GET_USER_ITEM");
-        public static readonly ServiceOperation GiveUserItemTo = new("GIVE_USER_ITEM_TO");
-        public static readonly ServiceOperation PurchaseUserItem = new("PURCHASE_USER_ITEM");
-        public static readonly ServiceOperation ReceiveUserItemFrom = new("RECEIVE_USER_ITEM_FROM");
-        public static readonly ServiceOperation SellUserItem = new("SELL_USER_ITEM");
-        public static readonly ServiceOperation UpdateUserItemData = new("UPDATE_USER_ITEM_DATA");
-        public static readonly ServiceOperation UseUserItem = new("USE_USER_ITEM");
-        public static readonly ServiceOperation PublishUserItemToBlockchain = new("PUBLISH_USER_ITEM_TO_BLOCKCHAIN");
-        public static readonly ServiceOperation RefreshBlockchainUserItems = new("REFRESH_BLOCKCHAIN_USER_ITEMS");
-        public static readonly ServiceOperation RemoveUserItemFromBlockchain = new("REMOVE_USER_ITEM_FROM_BLOCKCHAIN");
-        public static readonly ServiceOperation GetPromotionDetails = new("GET_ITEMS_ON_PROMOTION");
-        public static readonly ServiceOperation GetItemPromotionDetails = new("GET_ITEM_PROMOTION_DETAILS");
-        public static readonly ServiceOperation OpenBundle = new("OPEN_BUNDLE");
+        public static readonly ServiceOperation AwardUserItem = new ServiceOperation("AWARD_USER_ITEM");
+        public static readonly ServiceOperation DropUserItem = new ServiceOperation("DROP_USER_ITEM");
+        public static readonly ServiceOperation GetUserItemsPage = new ServiceOperation("GET_USER_ITEMS_PAGE");
+        public static readonly ServiceOperation GetUserItemsPageOffset = new ServiceOperation("GET_USER_ITEMS_PAGE_OFFSET");
+        public static readonly ServiceOperation GetUserItem = new ServiceOperation("GET_USER_ITEM");
+        public static readonly ServiceOperation GiveUserItemTo = new ServiceOperation("GIVE_USER_ITEM_TO");
+        public static readonly ServiceOperation PurchaseUserItem = new ServiceOperation("PURCHASE_USER_ITEM");
+        public static readonly ServiceOperation ReceiveUserItemFrom = new ServiceOperation("RECEIVE_USER_ITEM_FROM");
+        public static readonly ServiceOperation SellUserItem = new ServiceOperation("SELL_USER_ITEM");
+        public static readonly ServiceOperation UpdateUserItemData = new ServiceOperation("UPDATE_USER_ITEM_DATA");
+        public static readonly ServiceOperation UseUserItem = new ServiceOperation("USE_USER_ITEM");
+        public static readonly ServiceOperation PublishUserItemToBlockchain = new ServiceOperation("PUBLISH_USER_ITEM_TO_BLOCKCHAIN");
+        public static readonly ServiceOperation RefreshBlockchainUserItems = new ServiceOperation("REFRESH_BLOCKCHAIN_USER_ITEMS");
+        public static readonly ServiceOperation RemoveUserItemFromBlockchain = new ServiceOperation("REMOVE_USER_ITEM_FROM_BLOCKCHAIN");
+        public static readonly ServiceOperation GetPromotionDetails = new ServiceOperation("GET_ITEMS_ON_PROMOTION");
+        public static readonly ServiceOperation GetItemPromotionDetails = new ServiceOperation("GET_ITEM_PROMOTION_DETAILS");
+        public static readonly ServiceOperation OpenBundle = new ServiceOperation("OPEN_BUNDLE");
 
         //Group File Services
-        public static readonly ServiceOperation CheckFilenameExists = new("CHECK_FILENAME_EXISTS");
-        public static readonly ServiceOperation CheckFullpathFilenameExists = new("CHECK_FULLPATH_FILENAME_EXISTS");
-        public static readonly ServiceOperation CopyFile = new("COPY_FILE");
-        public static readonly ServiceOperation DeleteFile = new("DELETE_FILE");
-        public static readonly ServiceOperation MoveFile = new("MOVE_FILE");
-        public static readonly ServiceOperation MoveUserToGroupFile = new("MOVE_USER_TO_GROUP_FILE");
-        public static readonly ServiceOperation UpdateFileInfo = new("UPDATE_FILE_INFO");
+        public static readonly ServiceOperation CheckFilenameExists = new ServiceOperation("CHECK_FILENAME_EXISTS");
+        public static readonly ServiceOperation CheckFullpathFilenameExists = new ServiceOperation("CHECK_FULLPATH_FILENAME_EXISTS");
+        public static readonly ServiceOperation CopyFile = new ServiceOperation("COPY_FILE");
+        public static readonly ServiceOperation DeleteFile = new ServiceOperation("DELETE_FILE");
+        public static readonly ServiceOperation MoveFile = new ServiceOperation("MOVE_FILE");
+        public static readonly ServiceOperation MoveUserToGroupFile = new ServiceOperation("MOVE_USER_TO_GROUP_FILE");
+        public static readonly ServiceOperation UpdateFileInfo = new ServiceOperation("UPDATE_FILE_INFO");
 
         #endregion
 
@@ -547,33 +547,34 @@ namespace BrainCloud
 
         #region Overrides and Operators
 
-        public readonly override bool Equals(object obj)
+        public override bool Equals(object obj)
         {
-            if (obj is not ServiceOperation s)
-                return false;
-
-            return Equals(s);
+            return obj is ServiceOperation other && Equals(other);
         }
 
-        public readonly bool Equals(ServiceOperation other)
+        public bool Equals(ServiceOperation other)
         {
-            if (GetType() != other.GetType())
-                return false;
-
             return Value == other.Value;
         }
 
-        public readonly int CompareTo(ServiceOperation other)
+        public int CompareTo(object obj)
         {
-            if (GetType() != other.GetType())
-                return 1;
+            if (obj is ServiceOperation other)
+            {
+                return CompareTo(other);
+            }
 
+            return 1;
+        }
+
+        public int CompareTo(ServiceOperation other)
+        {
             return Value.CompareTo(other.Value);
         }
 
-        public readonly override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => Value.GetHashCode();
 
-        public readonly override string ToString() => Value;
+        public override string ToString() => Value;
 
         public static implicit operator string(ServiceOperation v) => v.Value;
 


### PR DESCRIPTION
Removing syntactic sugar of newer C# features so that we can maintain compatibility with older versions of Unity. This only really affected a handful of files so it is worth doing I think.

I also added the `JSON_COMPATIBILITY_FLAG` as a define in `BrainCloudComms.cs` for the handful of cases where custom Json handling classes (which means not the built-in JsonFX and Unity's JsonUtility) had trouble with leading ,0s in number values.