### PR TITLE
Fix flaky C# unit test setup auth retries and timeouts

### DIFF
--- a/BrainCloudClient/tests/TestComms.cs
+++ b/BrainCloudClient/tests/TestComms.cs
@@ -77,7 +77,7 @@ namespace BrainCloudTests
             _bc.Init(ServerUrl + "unitTestFail", Secret, AppId, Version);
             _bc.Client.EnableLogging(true);
             // Init() recreates the comms layer, resetting _authPacketTimeoutSecs to the
-            // default 15 s.  Re-apply 30 s so the request waits long enough for the server
+            // default 15 s.  Re-apply 30s so the request waits long enough for the server
             // to return a parseable (but invalid) response rather than timing out first.
             _bc.Client.SetAuthenticationPacketTimeout(30);
 

--- a/BrainCloudClient/tests/TestComms.cs
+++ b/BrainCloudClient/tests/TestComms.cs
@@ -71,11 +71,15 @@ namespace BrainCloudTests
             tr.Run();
         }
 
-        [Test] 
+        [Test]
         public void TestBadUrl()
         {
             _bc.Init(ServerUrl + "unitTestFail", Secret, AppId, Version);
             _bc.Client.EnableLogging(true);
+            // Init() recreates the comms layer, resetting _authPacketTimeoutSecs to the
+            // default 15 s.  Re-apply 30 s so the request waits long enough for the server
+            // to return a parseable (but invalid) response rather than timing out first.
+            _bc.Client.SetAuthenticationPacketTimeout(30);
 
             TestResult tr = new TestResult(_bc);
             tr.SetTimeToWaitSecs(120);

--- a/BrainCloudClient/tests/TestFile.cs
+++ b/BrainCloudClient/tests/TestFile.cs
@@ -361,7 +361,7 @@ namespace BrainCloudTests
             BrainCloudClient client = _bc.Client;
 
             client.Update();
-            while (_returnCount < uploadIds.Length && count < 1000 * 30)
+            while (_returnCount < uploadIds.Length && count < 1000 * 300)
             {
 
                 for (int i = 0; i < uploadIds.Length; i++)

--- a/BrainCloudClient/tests/TestFixtureBase.cs
+++ b/BrainCloudClient/tests/TestFixtureBase.cs
@@ -69,31 +69,53 @@ namespace BrainCloudTests
                 bool authenticated = false;
                 for (int attempt = 0; attempt < 3 && !authenticated; attempt++)
                 {
-                    TestResult tr = new TestResult(_bc);
-                    _bc.Client.AuthenticationService.AuthenticateUniversal(
-                        GetUser(Users.UserA).Id,
-                        GetUser(Users.UserA).Password,
-                        true,
-                        tr.ApiSuccess, tr.ApiError);
+                    if (attempt > 0)
+                    {
+                        // Clean up the timed-out request state before retrying.
+                        _bc.Client.ResetCommunication();
+                    }
+
                     try
                     {
-                        tr.Run();
-                        authenticated = true;
+                        // Re-apply the 30 s timeout here because a successful TestUser
+                        // authentication inside GetUser() triggers the SDK's on-success
+                        // reset, which sets _authPacketTimeoutSecs back to the list default
+                        // (15 s), silently undoing the value we set above.
+                        _bc.Client.SetAuthenticationPacketTimeout(30);
+
+                        TestResult tr = new TestResult(_bc);
+                        _bc.Client.AuthenticationService.AuthenticateUniversal(
+                            GetUser(Users.UserA).Id,
+                            GetUser(Users.UserA).Password,
+                            true,
+                            tr.ApiSuccess, tr.ApiError);
+
+                        if (tr.RunRetry())
+                        {
+                            authenticated = true;
+                        }
+                        else
+                        {
+                            lastException = new Exception("Authentication returned error (status " + tr.m_statusCode + ", reason " + tr.m_reasonCode + ")");
+                            attemptStatuses.Add(tr.m_statusCode);
+                            Console.WriteLine("Setup auth attempt " + (attempt + 1) + " failed (status " + tr.m_statusCode + "), " +
+                                              (attempt < 2 ? "retrying..." : "giving up."));
+                        }
                     }
                     catch (Exception e)
                     {
                         lastException = e;
-                        attemptStatuses.Add(tr.m_statusCode);
-                        Console.WriteLine("Setup auth attempt " + (attempt + 1) + " failed (status " + tr.m_statusCode + "), " +
-                                          (attempt < 2 ? "retrying..." : "giving up."));
+                        attemptStatuses.Add(0);
+                        Console.WriteLine("Setup auth attempt " + (attempt + 1) + " failed: " + e.Message +
+                                          (attempt < 2 ? " — retrying..." : " — giving up."));
                     }
                 }
 
                 if (!authenticated)
                 {
-                    Assert.Inconclusive("Setup authentication failed after " + attemptStatuses.Count + 
+                    Assert.Inconclusive("Setup authentication failed after " + attemptStatuses.Count +
                                         " attempts. Statuses: [" + string.Join(", ", attemptStatuses) + "]. " +
-                                        "This is likely a CI network/timeout issue, not a test regression." + 
+                                        "This is likely a CI network/timeout issue, not a test regression. " +
                                         "Exception caught: " + lastException);
                 }
             }


### PR DESCRIPTION
- TestFixtureBase: move GetUser() inside try-catch so TestUser init failures are retried; re-apply SetAuthenticationPacketTimeout(30) inside the loop since an auth success resets it to 15 s; call ResetCommunication() before each retry
- TestFile: increase WaitForReturn cap from 30 s to 300 s for slow CI
- TestComms: re-apply 30 s auth timeout after Init() in TestBadUrl, which resets the comms layer and drops the timeout back to 15s

Tests seen passing successfully here: https://clientjenkins.bitheads.com/job/bitHeads_BrainCloud_CSharp_UnitTests/43/